### PR TITLE
Add space to Markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,171 +4,171 @@ Practical-Vim-Notes
 # Content
 
 ## 1.The Vim Way
-Tip 1. [Meet the Dot Command](tip1.md): `.`, `x`, `u`, `dd`, `>G`, `i`, `<Esc>`  
-Tip 2. [Don’t Repeat Yourself](tip2.md): `$`, `a`, `A`  
-Tip 3. [Take One Step Back, Then Three Forward](tip3.md): `f{char}`, `s`, `;`   
-Tip 4. [Act, Repeat, Reverse](tip4.md): `F{char}/T{char}`, `/pattern<CR>`, `:s/target/replacement`  
-Tip 5. [Find and Replace by Hand](tip5.md): `/target`, `*`, `*nn`, `cw`  
+Tip 1. [Meet the Dot Command](tip1.md): `.`, `x`, `u`, `dd`, `>G`, `i`, `<Esc>`
+Tip 2. [Don’t Repeat Yourself](tip2.md): `$`, `a`, `A`
+Tip 3. [Take One Step Back, Then Three Forward](tip3.md): `f{char}`, `s`, `;`
+Tip 4. [Act, Repeat, Reverse](tip4.md): `F{char}/T{char}`, `/pattern<CR>`, `:s/target/replacement`
+Tip 5. [Find and Replace by Hand](tip5.md): `/target`, `*`, `*nn`, `cw`
 Tip 6. [Meet the Dot Formula](tip6.md): **One key to move, One key to execute**
 
 
 
-Part I — Modes  
-## 2. Normal Mode  
-Tip 7. [Pause with Your Brush Off the Page](tip7.md)  
-Tip 8. [Chunk Your Undos](tip8.md)  
-Tip 9. [Compose Repeatable Changes](tip9.md): `db`, `b`, `dw`, `daw`   
-Tip 10. [Use Counts to Do Simple Arithmetic](tip10.md): `<C-a>`, `<C-x>`, `yyp`, `cw`, `cW`  
-Tip 11. [Don’t Count If You Can Repeat](tip11.md): `d2w/W`, `2dw/W`, `dw.`  
-Tip 12. [Combine and Conquer](tip12.md): `gu`, `gU`, `y`, `d`, `c`, `=`  
-## 3. Insert Mode  
-Tip 13. [Make Corrections Instantly from Insert Mode](tip13.md): `<C-h>`, `<C-w>`, `<C-u>`  
-Tip 14. [Get Back to Normal Mode](tip14.md): `<Esc>`, `<C-[>`, `<C-o>`, `zz`  
-Tip 15. [Paste from a Register Without Leaving Insert Mode](tip15.md): `yt,`, `<C-r>0`  
-Tip 16. [Do Back-of-the-Envelope Calculations in Place](tip16.md): `<C-r>=`  
-Tip 17. [Insert Unusual Characters by Character Code](tip17.md): `ga`, `<C-v>`, `<C-k`  
-Tip 18. [Insert Unusual Characters by Digraph](tip18.md): `<C-k>{char1}{char2}`  
-Tip 19. [Overwrite Existing Text with Replace Mode](tip19.md): `R`, `gR`, `r`, `gr`  
+Part I — Modes
+## 2. Normal Mode
+Tip 7. [Pause with Your Brush Off the Page](tip7.md)
+Tip 8. [Chunk Your Undos](tip8.md)
+Tip 9. [Compose Repeatable Changes](tip9.md): `db`, `b`, `dw`, `daw`
+Tip 10. [Use Counts to Do Simple Arithmetic](tip10.md): `<C-a>`, `<C-x>`, `yyp`, `cw`, `cW`
+Tip 11. [Don’t Count If You Can Repeat](tip11.md): `d2w/W`, `2dw/W`, `dw.`
+Tip 12. [Combine and Conquer](tip12.md): `gu`, `gU`, `y`, `d`, `c`, `=`
+## 3. Insert Mode
+Tip 13. [Make Corrections Instantly from Insert Mode](tip13.md): `<C-h>`, `<C-w>`, `<C-u>`
+Tip 14. [Get Back to Normal Mode](tip14.md): `<Esc>`, `<C-[>`, `<C-o>`, `zz`
+Tip 15. [Paste from a Register Without Leaving Insert Mode](tip15.md): `yt,`, `<C-r>0`
+Tip 16. [Do Back-of-the-Envelope Calculations in Place](tip16.md): `<C-r>=`
+Tip 17. [Insert Unusual Characters by Character Code](tip17.md): `ga`, `<C-v>`, `<C-k`
+Tip 18. [Insert Unusual Characters by Digraph](tip18.md): `<C-k>{char1}{char2}`
+Tip 19. [Overwrite Existing Text with Replace Mode](tip19.md): `R`, `gR`, `r`, `gr`
 ## 4. Visual Mode
-Tip 20. [Grok Visual Mode](tip20.md): `viw`, `c`  
-Tip 21. [Define a Visual Selection](tip21.md): `v`, `V`, `<C-v>`, `gv`, `o`, `e`  
-Tip 22. [Repeat Line-Wise Visual Commands](tip22.md): `<`, `>`  
-Tip 23. [Prefer Operators to Visual Commands Where Possible](tip23.md): `vit`, `U`  
-Tip 24. [Edit Tabular Data with Visual-Block Mode](tip24.md): `3j`, `r`, `yyp`  
-Tip 25. [Change Columns of Text](tip25.md):   
-Tip 26. [Append After a Ragged Visual Block](tip26.md): `$`  
+Tip 20. [Grok Visual Mode](tip20.md): `viw`, `c`
+Tip 21. [Define a Visual Selection](tip21.md): `v`, `V`, `<C-v>`, `gv`, `o`, `e`
+Tip 22. [Repeat Line-Wise Visual Commands](tip22.md): `<`, `>`
+Tip 23. [Prefer Operators to Visual Commands Where Possible](tip23.md): `vit`, `U`
+Tip 24. [Edit Tabular Data with Visual-Block Mode](tip24.md): `3j`, `r`, `yyp`
+Tip 25. [Change Columns of Text](tip25.md):
+Tip 26. [Append After a Ragged Visual Block](tip26.md): `$`
 ## 5. Command-Line Mode
-Tip 27. [Meet Vim’s Command Line](tip27.md): `:`, `<C-w><C-u>`, `<C-v><C-k>`, `<C-r>{register}`  
-Tip 28. [Execute a Command on One or More Consecutive Lines](tip28.md): `:print`, `:digit`, `:$`, `:3p`, `:3d`, `:2,5p`, `.`, `:%p`, `:%s/old/new/`, `'<`, `'>`, `:/<html>/,/<\/html>/p`  
-Tip 29. [Duplicate or Move Lines Using ‘:t’ and ‘:m’ Commands](tip29.md): `:copy :co :t`, `:move :m`, `dGp`  
-Tip 30. [Run Normal Mode Commands Across a Range](tip30.md): `:normal`, `%normal A;`, `%normal i//`  
-Tip 31. [Repeat the Last Ex Command](tip31.md): `:@:`, `:@@`, `:bn[ext]`, `:bp[revious]`, `<C-o>`  
-Tip 32. [Tab-Complete Your Ex Commands](tip32.md): `:col<C-d>`  
-Tip 33. [Insert the Current Word at the Command Prompt](tip33.md): `<C-r><C-w>`  
-Tip 34. [Recall Commands from History](tip34.md): `q:`, `<C-f>`  
-Tip 35. [Run Commands in the Shell](tip35.md): `:!ls`, `:ls`, `:!ruby %`, `:shell`, `<C-z>`, `jobs`, `fg`, `:read !{cmd}`, `:write !{cmd}`, `:[range]!{cmd/filter}`, `:2,$!sort -t',' -k2`, `!{motion}`, `!G`  
+Tip 27. [Meet Vim’s Command Line](tip27.md): `:`, `<C-w><C-u>`, `<C-v><C-k>`, `<C-r>{register}`
+Tip 28. [Execute a Command on One or More Consecutive Lines](tip28.md): `:print`, `:digit`, `:$`, `:3p`, `:3d`, `:2,5p`, `.`, `:%p`, `:%s/old/new/`, `'<`, `'>`, `:/<html>/,/<\/html>/p`
+Tip 29. [Duplicate or Move Lines Using ‘:t’ and ‘:m’ Commands](tip29.md): `:copy :co :t`, `:move :m`, `dGp`
+Tip 30. [Run Normal Mode Commands Across a Range](tip30.md): `:normal`, `%normal A;`, `%normal i//`
+Tip 31. [Repeat the Last Ex Command](tip31.md): `:@:`, `:@@`, `:bn[ext]`, `:bp[revious]`, `<C-o>`
+Tip 32. [Tab-Complete Your Ex Commands](tip32.md): `:col<C-d>`
+Tip 33. [Insert the Current Word at the Command Prompt](tip33.md): `<C-r><C-w>`
+Tip 34. [Recall Commands from History](tip34.md): `q:`, `<C-f>`
+Tip 35. [Run Commands in the Shell](tip35.md): `:!ls`, `:ls`, `:!ruby %`, `:shell`, `<C-z>`, `jobs`, `fg`, `:read !{cmd}`, `:write !{cmd}`, `:[range]!{cmd/filter}`, `:2,$!sort -t',' -k2`, `!{motion}`, `!G`
 
 
-Part II — Files  
+Part II — Files
 ## 6. Manage Multiple Files
-Tip 36. [Track Open Files with the Buffer List](tip36.md): `:bnext`, `:ls`, `<C-^>`, `:bprev`, `:bfirst`, `:blast`, `:buffer N`, `:buffer {bufname}`, `:bufdo`, `:argdo`, `:bd[elete]`  
-Tip 37. [Group Buffers into a Collection with the Argument List](tip37.md): `:args {arglist}`  
-Tip 38. [Manage Hidden Files](tip38.md): `:wirte`, `:edit!`, `qall!`, `:wall`,  
-Tip 39. [Divide Your Workspace into Split Windows](tip39.md): `<C-w>s`, `<C-w>v`, `:edit`, `:close`, `:only`  
-Tip 40. [Organize Your Window Layouts with Tab Pages](tip40.md): `:lcd{path}`, `:tabe[dit] {filename}`, `:tabmove [N]`  
+Tip 36. [Track Open Files with the Buffer List](tip36.md): `:bnext`, `:ls`, `<C-^>`, `:bprev`, `:bfirst`, `:blast`, `:buffer N`, `:buffer {bufname}`, `:bufdo`, `:argdo`, `:bd[elete]`
+Tip 37. [Group Buffers into a Collection with the Argument List](tip37.md): `:args {arglist}`
+Tip 38. [Manage Hidden Files](tip38.md): `:wirte`, `:edit!`, `qall!`, `:wall`,
+Tip 39. [Divide Your Workspace into Split Windows](tip39.md): `<C-w>s`, `<C-w>v`, `:edit`, `:close`, `:only`
+Tip 40. [Organize Your Window Layouts with Tab Pages](tip40.md): `:lcd{path}`, `:tabe[dit] {filename}`, `:tabmove [N]`
 ## 7. Open Files and Save Them to Disk
-Tip 41. [Open a File by Its Filepath Using ':edit'](tip41.md): `:edit %<Tab>`, `:edit %:h<Tab>`  
-Tip 42. [Open a File by Its Filename Using ':find'](tip42.md): `:find`, `:set path+=app/**`  
-Tip 43. [Explore the File System with netrw](tip43.md): `:edit .`, `:e.`, `:Explore`, `:E.`  
-Tip 44. [Save Files to Nonexistent Directories](tip44.md): `<C-g>`, `:!mkdir -p %:h`  
-Tip 45. [Save a File as the Super User](tip45.md): `:w !sudo tee % > /dev/null`  
-  
-  
-  
-Part III — Getting Around Faster  
+Tip 41. [Open a File by Its Filepath Using ':edit'](tip41.md): `:edit %<Tab>`, `:edit %:h<Tab>`
+Tip 42. [Open a File by Its Filename Using ':find'](tip42.md): `:find`, `:set path+=app/**`
+Tip 43. [Explore the File System with netrw](tip43.md): `:edit .`, `:e.`, `:Explore`, `:E.`
+Tip 44. [Save Files to Nonexistent Directories](tip44.md): `<C-g>`, `:!mkdir -p %:h`
+Tip 45. [Save a File as the Super User](tip45.md): `:w !sudo tee % > /dev/null`
+
+
+
+Part III — Getting Around Faster
 ## 8. Navigate Inside Files with Motions
-Tip 46. [Keep Your Fingers on the Home Row](tip46.md): `h,j,k,l`  
-Tip 47. [Distinguish Between Real Lines and Display Lines](tip47.md): `gj`, `gk`, `g0`, `g$`, `g^`  
-Tip 48. [Move Word-Wise](tip48.md): `w`, `b`, `e`, `ge`, `ea`, `gea`, `W`, `cW`  
-Tip 49. [Find by Character](tip49.md): `f{char}`, `;`, `,`, `F{char}`, `t{char}`, `T{char}`, `dt.`  
-Tip 50. [Search to Navigate](tip50.md): `/{char}`, `n`, `N`  
-Tip 51. [Trace Your Selection with Precision Text Objects](tip51.md): `vi}`, `a"`, `i"`, `at`, `it`  
-Tip 52. [Delete Around, or Change Inside](tip52.md): `iw`, `iW`, `is`, `ip`, `aw`, `aW`, `as`, `ap`  
-Tip 53. [Mark Your Place and Snap Back to It](tip53.md): `m{a-zA-Z}`, `'{mark}`  
-Tip 54. [Jump Between Matching Parentheses](tip54.md): `%`, `S"`  
+Tip 46. [Keep Your Fingers on the Home Row](tip46.md): `h,j,k,l`
+Tip 47. [Distinguish Between Real Lines and Display Lines](tip47.md): `gj`, `gk`, `g0`, `g$`, `g^`
+Tip 48. [Move Word-Wise](tip48.md): `w`, `b`, `e`, `ge`, `ea`, `gea`, `W`, `cW`
+Tip 49. [Find by Character](tip49.md): `f{char}`, `;`, `,`, `F{char}`, `t{char}`, `T{char}`, `dt.`
+Tip 50. [Search to Navigate](tip50.md): `/{char}`, `n`, `N`
+Tip 51. [Trace Your Selection with Precision Text Objects](tip51.md): `vi}`, `a"`, `i"`, `at`, `it`
+Tip 52. [Delete Around, or Change Inside](tip52.md): `iw`, `iW`, `is`, `ip`, `aw`, `aW`, `as`, `ap`
+Tip 53. [Mark Your Place and Snap Back to It](tip53.md): `m{a-zA-Z}`, `'{mark}`
+Tip 54. [Jump Between Matching Parentheses](tip54.md): `%`, `S"`
 ## 9. Navigate Between Files with Jumps
-Tip 55. [Traverse the Jump List](tip55.md): `<C-o>`, `<C-i>`  
-Tip 56. [Traverse the Change List](tip56.md): `:changes`, **`.**, **`^**  
-Tip 57. [Jump to the Filename Under the Cursor](tip57.md): `gf`  
-Tip 58. [Snap Between Files Using Global Marks](tip58.md): `:vimgrep`  
-  
-  
-  
+Tip 55. [Traverse the Jump List](tip55.md): `<C-o>`, `<C-i>`
+Tip 56. [Traverse the Change List](tip56.md): `:changes`, **`.**, **`^**
+Tip 57. [Jump to the Filename Under the Cursor](tip57.md): `gf`
+Tip 58. [Snap Between Files Using Global Marks](tip58.md): `:vimgrep`
+
+
+
 Part IV — Registers
 ## 10. Copy and Paste
-Tip 59. [Delete, Yank, and Put with Vim’s Unnamed Register](tip59.md): `x`, `p`, `xp`, `dd`, `ddp`, `yyp`, `P`, `diw`  
-Tip 60. [Grok Vim’s Registers](tip60.md): `"{register}`, `"ayiw`, `"bdd`, `"ap`, `"bp`, `:delete c`, `:put c`, `""p`, `"0P`, `:reg "0`, `"_d{motion}`, `"+`, `"+p <C-r>+`  
-Tip 61. [Replace a Visual Selection with a Register](tip61.md): `m{char}`, ``{char}`  
-Tip 62. [Paste from a Register](tip62.md): `<C-r>{register}`, `p`, `P`, `gp`, `gP`  
-Tip 63. [Interact with the System Clipboard](tip63.md): `:set pastetoggle=<f5>`  
+Tip 59. [Delete, Yank, and Put with Vim’s Unnamed Register](tip59.md): `x`, `p`, `xp`, `dd`, `ddp`, `yyp`, `P`, `diw`
+Tip 60. [Grok Vim’s Registers](tip60.md): `"{register}`, `"ayiw`, `"bdd`, `"ap`, `"bp`, `:delete c`, `:put c`, `""p`, `"0P`, `:reg "0`, `"_d{motion}`, `"+`, `"+p <C-r>+`
+Tip 61. [Replace a Visual Selection with a Register](tip61.md): `m{char}`, ``{char}`
+Tip 62. [Paste from a Register](tip62.md): `<C-r>{register}`, `p`, `P`, `gp`, `gP`
+Tip 63. [Interact with the System Clipboard](tip63.md): `:set pastetoggle=<f5>`
 
 
 
 ## 11. Macros
-Tip 64. [Record and Execute a Macro](tip64.md): `q`, `q{register}`, `:reg a`, `@{register}`, `@@`  
-Tip 65. [Normalize, Strike, Abort](tip65.md): `number@a`  
-Tip 66. [Play Back with a Count](tip66.md): `qq;.q`  
-Tip 67. [Repeat a Change on Contiguous Lines](tip67.md): `0`, `:normal @a`  
-Tip 68. [Append Commands to a Macro](tip68.md): `qa`, `qA`  
-Tip 69. [Act Upon a Collection of Files](tip69.md): `gg/class<CR>`, `:argdo`, `:edit!`, `:argdo normal @a`, `:argdo write`, `:wall`, `:wnext`  
-Tip 70. [Evaluate an Iterator to Number Items in a List](tip70.md): `:let i=0`, `:echo i`, `<C-r>=i<CR>`  
-Tip 71. [Edit the Contents of a Macro](tip71.md): `~`, `vU`, `:put a`  
+Tip 64. [Record and Execute a Macro](tip64.md): `q`, `q{register}`, `:reg a`, `@{register}`, `@@`
+Tip 65. [Normalize, Strike, Abort](tip65.md): `number@a`
+Tip 66. [Play Back with a Count](tip66.md): `qq;.q`
+Tip 67. [Repeat a Change on Contiguous Lines](tip67.md): `0`, `:normal @a`
+Tip 68. [Append Commands to a Macro](tip68.md): `qa`, `qA`
+Tip 69. [Act Upon a Collection of Files](tip69.md): `gg/class<CR>`, `:argdo`, `:edit!`, `:argdo normal @a`, `:argdo write`, `:wall`, `:wnext`
+Tip 70. [Evaluate an Iterator to Number Items in a List](tip70.md): `:let i=0`, `:echo i`, `<C-r>=i<CR>`
+Tip 71. [Edit the Contents of a Macro](tip71.md): `~`, `vU`, `:put a`
 
 
 
 Part V — Patterns
 ## 12. Matching Patterns and Literals
-Tip 72. Tune the Case Sensitivity of Search Patterns   
-Tip 73. Use the \v Pattern Switch for Regex Searches   
-Tip 74. Use the \V Literal Switch for Verbatim Searches   
-Tip 75. Use Parentheses to Capture Submatches   
-Tip 76. Stake the Boundaries of a Word   
-Tip 77. Stake the Boundaries of a Match   
-Tip 78. Escape Problem Characters   
+Tip 72. Tune the Case Sensitivity of Search Patterns
+Tip 73. Use the \v Pattern Switch for Regex Searches
+Tip 74. Use the \V Literal Switch for Verbatim Searches
+Tip 75. Use Parentheses to Capture Submatches
+Tip 76. Stake the Boundaries of a Word
+Tip 77. Stake the Boundaries of a Match
+Tip 78. Escape Problem Characters
 ## 13. Search
-Tip 79. Meet the Search Command   
-Tip 80. Highlight Search Matches   
-Tip 81. Preview the First Match Before Execution   
-Tip 82. Count the Matches for the Current Pattern   
-Tip 83. Offset the Cursor to the End of a Search Match   
-Tip 84. Operate on a Complete Search Match   
-Tip 85. Create Complex Patterns by Iterating upon Search History   
-Tip 86. Search for the Current Visual Selection   
+Tip 79. Meet the Search Command
+Tip 80. Highlight Search Matches
+Tip 81. Preview the First Match Before Execution
+Tip 82. Count the Matches for the Current Pattern
+Tip 83. Offset the Cursor to the End of a Search Match
+Tip 84. Operate on a Complete Search Match
+Tip 85. Create Complex Patterns by Iterating upon Search History
+Tip 86. Search for the Current Visual Selection
 ## 14. Substitution
-Tip 87. Meet the Substitute Command   
-Tip 88. Find and Replace Every Match in a File   
-Tip 89. Eyeball Each Substitution   
-Tip 90. Reuse the Last Search Pattern   
-Tip 91. Replace with the Contents of a Register   
-Tip 92. Repeat the Previous Substitute Command   
-Tip 93. Rearrange CSV Fields Using Submatches   
-Tip 94. Perform Arithmetic on the Replacement   
-Tip 95. Swap Two or More Words   
-Tip 96. Find and Replace Across Multiple Files   
+Tip 87. Meet the Substitute Command
+Tip 88. Find and Replace Every Match in a File
+Tip 89. Eyeball Each Substitution
+Tip 90. Reuse the Last Search Pattern
+Tip 91. Replace with the Contents of a Register
+Tip 92. Repeat the Previous Substitute Command
+Tip 93. Rearrange CSV Fields Using Submatches
+Tip 94. Perform Arithmetic on the Replacement
+Tip 95. Swap Two or More Words
+Tip 96. Find and Replace Across Multiple Files
 ## 15. Global Commands
-Tip 97. Meet the Global Command   
-Tip 98. Delete Lines Containing a Pattern   
-Tip 99. Collect TODO Items in a Register   
-Tip 100. Alphabetize the Properties of Each Rule in a CSS File   
- Part VI — Tools  
+Tip 97. Meet the Global Command
+Tip 98. Delete Lines Containing a Pattern
+Tip 99. Collect TODO Items in a Register
+Tip 100. Alphabetize the Properties of Each Rule in a CSS File
+ Part VI — Tools
 
 ## 16. Index and Navigate Source Code with ctags
-Tip 101. Meet ctags   
-Tip 102. Configure Vim to Work with ctags   
-Tip 103. Navigate Keyword Definitions with Vim’s Tag Navigation Commands   
-## 17. Compile Code and Navigate Errors with the Quickfix List  
-Tip 104. Compile Code Without Leaving Vim   
-Tip 105. Browse the Quickfix List   
-Tip 106. Recall Results from a Previous Quickfix List   
-Tip 107. Customize the External Compiler   
-## 18. Search Project-Wide with grep, vimgrep, and Others  
-Tip 108. Call grep Without Leaving Vim   
-Tip 109. Customize the grep Program   
-Tip 110. Grep with Vim’s Internal Search Engine   
+Tip 101. Meet ctags
+Tip 102. Configure Vim to Work with ctags
+Tip 103. Navigate Keyword Definitions with Vim’s Tag Navigation Commands
+## 17. Compile Code and Navigate Errors with the Quickfix List
+Tip 104. Compile Code Without Leaving Vim
+Tip 105. Browse the Quickfix List
+Tip 106. Recall Results from a Previous Quickfix List
+Tip 107. Customize the External Compiler
+## 18. Search Project-Wide with grep, vimgrep, and Others
+Tip 108. Call grep Without Leaving Vim
+Tip 109. Customize the grep Program
+Tip 110. Grep with Vim’s Internal Search Engine
 ## 19. Dial X for Autocompletion
-Tip 111. Meet Vim’s Keyword Autocompletion   
-Tip 112. Work with the Autocomplete Pop-Up Menu   
-Tip 113. Understand the Source of Keywords   
-Tip 114. Autocomplete Words from the Dictionary   
-Tip 115. Autocomplete Entire Lines   
-Tip 116. Autocomplete Filenames   
-Tip 117. Autocomplete with Context Awareness 
+Tip 111. Meet Vim’s Keyword Autocompletion
+Tip 112. Work with the Autocomplete Pop-Up Menu
+Tip 113. Understand the Source of Keywords
+Tip 114. Autocomplete Words from the Dictionary
+Tip 115. Autocomplete Entire Lines
+Tip 116. Autocomplete Filenames
+Tip 117. Autocomplete with Context Awareness
 ## 20. Find and Fix Typos with Vim’s Spell Checker
-Tip 118. Spell Check Your Work   
-Tip 119. Use Alternate Spelling Dictionaries   
-Tip 120. Add Words to the Spell File   
-Tip 121. Fix Spelling Errors from Insert Mode   
+Tip 118. Spell Check Your Work
+Tip 119. Use Alternate Spelling Dictionaries
+Tip 120. Add Words to the Spell File
+Tip 121. Fix Spelling Errors from Insert Mode
 ## 21. Now What?
-21.1 Keep Practicing!   
-21.2 Make Vim Your Own   
-21.3 Know the Saw, Then Sharpen It   
+21.1 Keep Practicing!
+21.2 Make Vim Your Own
+21.3 Know the Saw, Then Sharpen It

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Practical-Vim-Notes
 ===================
 
-#Content
+# Content
 
-##1.The Vim Way
+## 1.The Vim Way
 Tip 1. [Meet the Dot Command](tip1.md): `.`, `x`, `u`, `dd`, `>G`, `i`, `<Esc>`  
 Tip 2. [Don’t Repeat Yourself](tip2.md): `$`, `a`, `A`  
 Tip 3. [Take One Step Back, Then Three Forward](tip3.md): `f{char}`, `s`, `;`   
@@ -14,14 +14,14 @@ Tip 6. [Meet the Dot Formula](tip6.md): **One key to move, One key to execute**
 
 
 Part I — Modes  
-##2. Normal Mode  
+## 2. Normal Mode  
 Tip 7. [Pause with Your Brush Off the Page](tip7.md)  
 Tip 8. [Chunk Your Undos](tip8.md)  
 Tip 9. [Compose Repeatable Changes](tip9.md): `db`, `b`, `dw`, `daw`   
 Tip 10. [Use Counts to Do Simple Arithmetic](tip10.md): `<C-a>`, `<C-x>`, `yyp`, `cw`, `cW`  
 Tip 11. [Don’t Count If You Can Repeat](tip11.md): `d2w/W`, `2dw/W`, `dw.`  
 Tip 12. [Combine and Conquer](tip12.md): `gu`, `gU`, `y`, `d`, `c`, `=`  
-##3. Insert Mode  
+## 3. Insert Mode  
 Tip 13. [Make Corrections Instantly from Insert Mode](tip13.md): `<C-h>`, `<C-w>`, `<C-u>`  
 Tip 14. [Get Back to Normal Mode](tip14.md): `<Esc>`, `<C-[>`, `<C-o>`, `zz`  
 Tip 15. [Paste from a Register Without Leaving Insert Mode](tip15.md): `yt,`, `<C-r>0`  
@@ -29,7 +29,7 @@ Tip 16. [Do Back-of-the-Envelope Calculations in Place](tip16.md): `<C-r>=`
 Tip 17. [Insert Unusual Characters by Character Code](tip17.md): `ga`, `<C-v>`, `<C-k`  
 Tip 18. [Insert Unusual Characters by Digraph](tip18.md): `<C-k>{char1}{char2}`  
 Tip 19. [Overwrite Existing Text with Replace Mode](tip19.md): `R`, `gR`, `r`, `gr`  
-##4. Visual Mode
+## 4. Visual Mode
 Tip 20. [Grok Visual Mode](tip20.md): `viw`, `c`  
 Tip 21. [Define a Visual Selection](tip21.md): `v`, `V`, `<C-v>`, `gv`, `o`, `e`  
 Tip 22. [Repeat Line-Wise Visual Commands](tip22.md): `<`, `>`  
@@ -37,7 +37,7 @@ Tip 23. [Prefer Operators to Visual Commands Where Possible](tip23.md): `vit`, `
 Tip 24. [Edit Tabular Data with Visual-Block Mode](tip24.md): `3j`, `r`, `yyp`  
 Tip 25. [Change Columns of Text](tip25.md):   
 Tip 26. [Append After a Ragged Visual Block](tip26.md): `$`  
-##5. Command-Line Mode
+## 5. Command-Line Mode
 Tip 27. [Meet Vim’s Command Line](tip27.md): `:`, `<C-w><C-u>`, `<C-v><C-k>`, `<C-r>{register}`  
 Tip 28. [Execute a Command on One or More Consecutive Lines](tip28.md): `:print`, `:digit`, `:$`, `:3p`, `:3d`, `:2,5p`, `.`, `:%p`, `:%s/old/new/`, `'<`, `'>`, `:/<html>/,/<\/html>/p`  
 Tip 29. [Duplicate or Move Lines Using ‘:t’ and ‘:m’ Commands](tip29.md): `:copy :co :t`, `:move :m`, `dGp`  
@@ -50,13 +50,13 @@ Tip 35. [Run Commands in the Shell](tip35.md): `:!ls`, `:ls`, `:!ruby %`, `:shel
 
 
 Part II — Files  
-##6. Manage Multiple Files
+## 6. Manage Multiple Files
 Tip 36. [Track Open Files with the Buffer List](tip36.md): `:bnext`, `:ls`, `<C-^>`, `:bprev`, `:bfirst`, `:blast`, `:buffer N`, `:buffer {bufname}`, `:bufdo`, `:argdo`, `:bd[elete]`  
 Tip 37. [Group Buffers into a Collection with the Argument List](tip37.md): `:args {arglist}`  
 Tip 38. [Manage Hidden Files](tip38.md): `:wirte`, `:edit!`, `qall!`, `:wall`,  
 Tip 39. [Divide Your Workspace into Split Windows](tip39.md): `<C-w>s`, `<C-w>v`, `:edit`, `:close`, `:only`  
 Tip 40. [Organize Your Window Layouts with Tab Pages](tip40.md): `:lcd{path}`, `:tabe[dit] {filename}`, `:tabmove [N]`  
-##7. Open Files and Save Them to Disk
+## 7. Open Files and Save Them to Disk
 Tip 41. [Open a File by Its Filepath Using ':edit'](tip41.md): `:edit %<Tab>`, `:edit %:h<Tab>`  
 Tip 42. [Open a File by Its Filename Using ':find'](tip42.md): `:find`, `:set path+=app/**`  
 Tip 43. [Explore the File System with netrw](tip43.md): `:edit .`, `:e.`, `:Explore`, `:E.`  
@@ -66,7 +66,7 @@ Tip 45. [Save a File as the Super User](tip45.md): `:w !sudo tee % > /dev/null`
   
   
 Part III — Getting Around Faster  
-##8. Navigate Inside Files with Motions
+## 8. Navigate Inside Files with Motions
 Tip 46. [Keep Your Fingers on the Home Row](tip46.md): `h,j,k,l`  
 Tip 47. [Distinguish Between Real Lines and Display Lines](tip47.md): `gj`, `gk`, `g0`, `g$`, `g^`  
 Tip 48. [Move Word-Wise](tip48.md): `w`, `b`, `e`, `ge`, `ea`, `gea`, `W`, `cW`  
@@ -76,7 +76,7 @@ Tip 51. [Trace Your Selection with Precision Text Objects](tip51.md): `vi}`, `a"
 Tip 52. [Delete Around, or Change Inside](tip52.md): `iw`, `iW`, `is`, `ip`, `aw`, `aW`, `as`, `ap`  
 Tip 53. [Mark Your Place and Snap Back to It](tip53.md): `m{a-zA-Z}`, `'{mark}`  
 Tip 54. [Jump Between Matching Parentheses](tip54.md): `%`, `S"`  
-##9. Navigate Between Files with Jumps
+## 9. Navigate Between Files with Jumps
 Tip 55. [Traverse the Jump List](tip55.md): `<C-o>`, `<C-i>`  
 Tip 56. [Traverse the Change List](tip56.md): `:changes`, **`.**, **`^**  
 Tip 57. [Jump to the Filename Under the Cursor](tip57.md): `gf`  
@@ -85,7 +85,7 @@ Tip 58. [Snap Between Files Using Global Marks](tip58.md): `:vimgrep`
   
   
 Part IV — Registers
-##10. Copy and Paste
+## 10. Copy and Paste
 Tip 59. [Delete, Yank, and Put with Vim’s Unnamed Register](tip59.md): `x`, `p`, `xp`, `dd`, `ddp`, `yyp`, `P`, `diw`  
 Tip 60. [Grok Vim’s Registers](tip60.md): `"{register}`, `"ayiw`, `"bdd`, `"ap`, `"bp`, `:delete c`, `:put c`, `""p`, `"0P`, `:reg "0`, `"_d{motion}`, `"+`, `"+p <C-r>+`  
 Tip 61. [Replace a Visual Selection with a Register](tip61.md): `m{char}`, ``{char}`  
@@ -94,7 +94,7 @@ Tip 63. [Interact with the System Clipboard](tip63.md): `:set pastetoggle=<f5>`
 
 
 
-##11. Macros
+## 11. Macros
 Tip 64. [Record and Execute a Macro](tip64.md): `q`, `q{register}`, `:reg a`, `@{register}`, `@@`  
 Tip 65. [Normalize, Strike, Abort](tip65.md): `number@a`  
 Tip 66. [Play Back with a Count](tip66.md): `qq;.q`  
@@ -107,7 +107,7 @@ Tip 71. [Edit the Contents of a Macro](tip71.md): `~`, `vU`, `:put a`
 
 
 Part V — Patterns
-##12. Matching Patterns and Literals
+## 12. Matching Patterns and Literals
 Tip 72. Tune the Case Sensitivity of Search Patterns   
 Tip 73. Use the \v Pattern Switch for Regex Searches   
 Tip 74. Use the \V Literal Switch for Verbatim Searches   
@@ -115,7 +115,7 @@ Tip 75. Use Parentheses to Capture Submatches
 Tip 76. Stake the Boundaries of a Word   
 Tip 77. Stake the Boundaries of a Match   
 Tip 78. Escape Problem Characters   
-##13. Search
+## 13. Search
 Tip 79. Meet the Search Command   
 Tip 80. Highlight Search Matches   
 Tip 81. Preview the First Match Before Execution   
@@ -124,7 +124,7 @@ Tip 83. Offset the Cursor to the End of a Search Match
 Tip 84. Operate on a Complete Search Match   
 Tip 85. Create Complex Patterns by Iterating upon Search History   
 Tip 86. Search for the Current Visual Selection   
-##14. Substitution
+## 14. Substitution
 Tip 87. Meet the Substitute Command   
 Tip 88. Find and Replace Every Match in a File   
 Tip 89. Eyeball Each Substitution   
@@ -135,27 +135,27 @@ Tip 93. Rearrange CSV Fields Using Submatches
 Tip 94. Perform Arithmetic on the Replacement   
 Tip 95. Swap Two or More Words   
 Tip 96. Find and Replace Across Multiple Files   
-##15. Global Commands
+## 15. Global Commands
 Tip 97. Meet the Global Command   
 Tip 98. Delete Lines Containing a Pattern   
 Tip 99. Collect TODO Items in a Register   
 Tip 100. Alphabetize the Properties of Each Rule in a CSS File   
  Part VI — Tools  
 
-##16. Index and Navigate Source Code with ctags
+## 16. Index and Navigate Source Code with ctags
 Tip 101. Meet ctags   
 Tip 102. Configure Vim to Work with ctags   
 Tip 103. Navigate Keyword Definitions with Vim’s Tag Navigation Commands   
-##17. Compile Code and Navigate Errors with the Quickfix List  
+## 17. Compile Code and Navigate Errors with the Quickfix List  
 Tip 104. Compile Code Without Leaving Vim   
 Tip 105. Browse the Quickfix List   
 Tip 106. Recall Results from a Previous Quickfix List   
 Tip 107. Customize the External Compiler   
-##18. Search Project-Wide with grep, vimgrep, and Others  
+## 18. Search Project-Wide with grep, vimgrep, and Others  
 Tip 108. Call grep Without Leaving Vim   
 Tip 109. Customize the grep Program   
 Tip 110. Grep with Vim’s Internal Search Engine   
-##19. Dial X for Autocompletion
+## 19. Dial X for Autocompletion
 Tip 111. Meet Vim’s Keyword Autocompletion   
 Tip 112. Work with the Autocomplete Pop-Up Menu   
 Tip 113. Understand the Source of Keywords   
@@ -163,12 +163,12 @@ Tip 114. Autocomplete Words from the Dictionary
 Tip 115. Autocomplete Entire Lines   
 Tip 116. Autocomplete Filenames   
 Tip 117. Autocomplete with Context Awareness 
-##20. Find and Fix Typos with Vim’s Spell Checker
+## 20. Find and Fix Typos with Vim’s Spell Checker
 Tip 118. Spell Check Your Work   
 Tip 119. Use Alternate Spelling Dictionaries   
 Tip 120. Add Words to the Spell File   
 Tip 121. Fix Spelling Errors from Insert Mode   
-##21. Now What?
+## 21. Now What?
 21.1 Keep Practicing!   
 21.2 Make Vim Your Own   
 21.3 Know the Saw, Then Sharpen It   

--- a/tip1.md
+++ b/tip1.md
@@ -1,33 +1,33 @@
-#Tip1: Meet the Dot Command  
+# Tip1: Meet the Dot Command  
   
-##Dot:    
+## Dot:    
 >repeat the last change.  
   
-##x:  
+## x:  
 >delete the character under the cursor.  
   
-##u:  
+## u:  
 >undo the changes.  
   
-##dd:   
+## dd:   
 >delete current line as a whole.  
   
-##>G:    
+## >G:    
 >increase the indentation from the current line until the end of the file.  
   
-##h,j,k,l:     
+## h,j,k,l:     
 >h:left   
 >j:up    
 >k:down   
 >l:right    
   
-##i:  
+## i:  
 >enter Insert mode  
   
-##Esc:    
+## Esc:    
 >enter Normal mode  
   
-#Example:  
+# Example:  
 ![tip1](images/tip1.png)
   
-#[Contents](README.md) [Tip2](tip2.md)
+# [Contents](README.md) [Tip2](tip2.md)

--- a/tip1.md
+++ b/tip1.md
@@ -1,33 +1,33 @@
-# Tip1: Meet the Dot Command  
-  
-## Dot:    
->repeat the last change.  
-  
-## x:  
->delete the character under the cursor.  
-  
-## u:  
->undo the changes.  
-  
-## dd:   
->delete current line as a whole.  
-  
-## >G:    
->increase the indentation from the current line until the end of the file.  
-  
-## h,j,k,l:     
->h:left   
->j:up    
->k:down   
->l:right    
-  
-## i:  
->enter Insert mode  
-  
-## Esc:    
->enter Normal mode  
-  
-# Example:  
+# Tip1: Meet the Dot Command
+
+## Dot:
+>repeat the last change.
+
+## x:
+>delete the character under the cursor.
+
+## u:
+>undo the changes.
+
+## dd:
+>delete current line as a whole.
+
+## >G:
+>increase the indentation from the current line until the end of the file.
+
+## h,j,k,l:
+>h:left
+>j:up
+>k:down
+>l:right
+
+## i:
+>enter Insert mode
+
+## Esc:
+>enter Normal mode
+
+# Example:
 ![tip1](images/tip1.png)
-  
+
 # [Contents](README.md) [Tip2](tip2.md)

--- a/tip10.md
+++ b/tip10.md
@@ -1,32 +1,32 @@
-# Tip10: Use Counts to Do Simple Arithmetic  
-  
-  
-`<C-a>`  
->perform addition on numbers.  
-  
-`<C-x>`  
->perform subtraction on numbers.  
-   
-   
-**comment**: When run without a count they increment by one, but if we prefix a number, we can change by that number. For example, if we positioned our cursor on a `5` character, running `10<C-a>` would modify it to read `15`.  
-  
+# Tip10: Use Counts to Do Simple Arithmetic
 
-But what happens if the cursor is not positioned on a numeric digit? The documentation says that the `<C-a>` command will **“add [count] to the number at or after the cursor”** (see :h ctrl-a ). So if the cursor is not already positioned on a number, then the `<C-a>` command will look ahead for a digit on the current line. If it finds one, it jumps straight to it. We can use this to our advantage. 
-  
-## yyp  
->duplicate current line once  
-  
-## cw  
->delete character under the cursor and change to Insert mode.  
-  
-## cW  
->delete to the end of the word under the cursor and change to Insert mode.  
-  
-# Example:  
-![tip10](images/tip10.png)  
-# Take care:  
->If you answered 008, then you might be in for a surprise when you try using Vim’s `<C-a>` command on any number with a ****leading zero****. As is the convention in some programming languages, Vim interprets numerals with a leading zero to be in octal notation rather than in decimal. In the octal numeric system, `007` + `001` = `010`, which looks like the decimal ten but is actually an octal eight. Confused? If you work with octal numbers frequently, Vim’s default behavior might suit you. If you don’t, you probably want to add the following line to your **vimrc**:  
-`set nrformats=`  
-This will cause Vim to treat all numerals as decimal, regardless of whether they are padded with zeros.  
-  
+
+`<C-a>`
+>perform addition on numbers.
+
+`<C-x>`
+>perform subtraction on numbers.
+
+
+**comment**: When run without a count they increment by one, but if we prefix a number, we can change by that number. For example, if we positioned our cursor on a `5` character, running `10<C-a>` would modify it to read `15`.
+
+
+But what happens if the cursor is not positioned on a numeric digit? The documentation says that the `<C-a>` command will **“add [count] to the number at or after the cursor”** (see :h ctrl-a ). So if the cursor is not already positioned on a number, then the `<C-a>` command will look ahead for a digit on the current line. If it finds one, it jumps straight to it. We can use this to our advantage.
+
+## yyp
+>duplicate current line once
+
+## cw
+>delete character under the cursor and change to Insert mode.
+
+## cW
+>delete to the end of the word under the cursor and change to Insert mode.
+
+# Example:
+![tip10](images/tip10.png)
+# Take care:
+>If you answered 008, then you might be in for a surprise when you try using Vim’s `<C-a>` command on any number with a ****leading zero****. As is the convention in some programming languages, Vim interprets numerals with a leading zero to be in octal notation rather than in decimal. In the octal numeric system, `007` + `001` = `010`, which looks like the decimal ten but is actually an octal eight. Confused? If you work with octal numbers frequently, Vim’s default behavior might suit you. If you don’t, you probably want to add the following line to your **vimrc**:
+`set nrformats=`
+This will cause Vim to treat all numerals as decimal, regardless of whether they are padded with zeros.
+
 # [Tip9](tip9.md) [Tip11](tip11.md)

--- a/tip10.md
+++ b/tip10.md
@@ -1,4 +1,4 @@
-#Tip10: Use Counts to Do Simple Arithmetic  
+# Tip10: Use Counts to Do Simple Arithmetic  
   
   
 `<C-a>`  
@@ -13,20 +13,20 @@
 
 But what happens if the cursor is not positioned on a numeric digit? The documentation says that the `<C-a>` command will **“add [count] to the number at or after the cursor”** (see :h ctrl-a ). So if the cursor is not already positioned on a number, then the `<C-a>` command will look ahead for a digit on the current line. If it finds one, it jumps straight to it. We can use this to our advantage. 
   
-##yyp  
+## yyp  
 >duplicate current line once  
   
-##cw  
+## cw  
 >delete character under the cursor and change to Insert mode.  
   
-##cW  
+## cW  
 >delete to the end of the word under the cursor and change to Insert mode.  
   
-#Example:  
+# Example:  
 ![tip10](images/tip10.png)  
-#Take care:  
+# Take care:  
 >If you answered 008, then you might be in for a surprise when you try using Vim’s `<C-a>` command on any number with a ****leading zero****. As is the convention in some programming languages, Vim interprets numerals with a leading zero to be in octal notation rather than in decimal. In the octal numeric system, `007` + `001` = `010`, which looks like the decimal ten but is actually an octal eight. Confused? If you work with octal numbers frequently, Vim’s default behavior might suit you. If you don’t, you probably want to add the following line to your **vimrc**:  
 `set nrformats=`  
 This will cause Vim to treat all numerals as decimal, regardless of whether they are padded with zeros.  
   
-#[Tip9](tip9.md) [Tip11](tip11.md)
+# [Tip9](tip9.md) [Tip11](tip11.md)

--- a/tip11.md
+++ b/tip11.md
@@ -1,18 +1,18 @@
-#Tip11: Do Not Count If You Can Repeat  
+# Tip11: Do Not Count If You Can Repeat  
   
-##Goal: delete two words  
+## Goal: delete two words  
 ![tip11_1](images/tip11_1.png)  
   
-##d2w/W  
+## d2w/W  
 >delete two words  
   
-##2dw/W  
+## 2dw/W  
 >delete a word two times  
   
-##dw.  
+## dw.  
 >delete a word and then repeat  
   
-#Take care:   
+# Take care:   
 ![tip11_2](images/tip11_2.png)  
 >`d2w/W` and `2dw/W` are identical.`u`: the two words that were deleted will appear again. `.`: delete the next two words.  
   
@@ -20,6 +20,6 @@
   
 So, `d7w` == `dw......`  
   
-#Take the part you feel GOOD!  
+# Take the part you feel GOOD!  
   
-#[Tip10](tip10.md) [Tip12](tip12.md)
+# [Tip10](tip10.md) [Tip12](tip12.md)

--- a/tip11.md
+++ b/tip11.md
@@ -1,25 +1,25 @@
-# Tip11: Do Not Count If You Can Repeat  
-  
-## Goal: delete two words  
-![tip11_1](images/tip11_1.png)  
-  
-## d2w/W  
->delete two words  
-  
-## 2dw/W  
->delete a word two times  
-  
-## dw.  
->delete a word and then repeat  
-  
-# Take care:   
-![tip11_2](images/tip11_2.png)  
->`d2w/W` and `2dw/W` are identical.`u`: the two words that were deleted will appear again. `.`: delete the next two words.  
-  
->`dw.`: `u`: `uu` or `2u` to restore the two words that were deleted. `.`: delete the next one word.  
-  
-So, `d7w` == `dw......`  
-  
-# Take the part you feel GOOD!  
-  
+# Tip11: Do Not Count If You Can Repeat
+
+## Goal: delete two words
+![tip11_1](images/tip11_1.png)
+
+## d2w/W
+>delete two words
+
+## 2dw/W
+>delete a word two times
+
+## dw.
+>delete a word and then repeat
+
+# Take care:
+![tip11_2](images/tip11_2.png)
+>`d2w/W` and `2dw/W` are identical.`u`: the two words that were deleted will appear again. `.`: delete the next two words.
+
+>`dw.`: `u`: `uu` or `2u` to restore the two words that were deleted. `.`: delete the next one word.
+
+So, `d7w` == `dw......`
+
+# Take the part you feel GOOD!
+
 # [Tip10](tip10.md) [Tip12](tip12.md)

--- a/tip12.md
+++ b/tip12.md
@@ -1,12 +1,12 @@
-# Tip12: Combine and Conquer  
-  
-# Action = Operator + Motion  
-  
-# Rules:  
->an action is composed from an operator followed by a motion.  
-  
->when an operator command is invoked in duplicate, it acts upon the current line.  
-  
-![tip12](images/tip12.png)  
-  
+# Tip12: Combine and Conquer
+
+# Action = Operator + Motion
+
+# Rules:
+>an action is composed from an operator followed by a motion.
+
+>when an operator command is invoked in duplicate, it acts upon the current line.
+
+![tip12](images/tip12.png)
+
 # [Tip11](tip11.md) [Tip13](tip13.md)

--- a/tip12.md
+++ b/tip12.md
@@ -1,12 +1,12 @@
-#Tip12: Combine and Conquer  
+# Tip12: Combine and Conquer  
   
-#Action = Operator + Motion  
+# Action = Operator + Motion  
   
-#Rules:  
+# Rules:  
 >an action is composed from an operator followed by a motion.  
   
 >when an operator command is invoked in duplicate, it acts upon the current line.  
   
 ![tip12](images/tip12.png)  
   
-#[Tip11](tip11.md) [Tip13](tip13.md)
+# [Tip11](tip11.md) [Tip13](tip13.md)

--- a/tip13.md
+++ b/tip13.md
@@ -1,10 +1,10 @@
-#Tip13: Make Corrections Instantly from Insert Mode  
+# Tip13: Make Corrections Instantly from Insert Mode  
   
-##Left Ctrl  
+## Left Ctrl  
 ![tip13](images/tip13.png)  
   
-##Note:  
+## Note:  
 >These commands works well with VIM and bash shell.  
   
 
-#[Tip12](tip12.md) [Tip14](tip14.md)  
+# [Tip12](tip12.md) [Tip14](tip14.md)  

--- a/tip13.md
+++ b/tip13.md
@@ -1,10 +1,10 @@
-# Tip13: Make Corrections Instantly from Insert Mode  
-  
-## Left Ctrl  
-![tip13](images/tip13.png)  
-  
-## Note:  
->These commands works well with VIM and bash shell.  
-  
+# Tip13: Make Corrections Instantly from Insert Mode
 
-# [Tip12](tip12.md) [Tip14](tip14.md)  
+## Left Ctrl
+![tip13](images/tip13.png)
+
+## Note:
+>These commands works well with VIM and bash shell.
+
+
+# [Tip12](tip12.md) [Tip14](tip14.md)

--- a/tip14.md
+++ b/tip14.md
@@ -1,11 +1,11 @@
-# Tip14: Get Back to Normal Mode  
-   
-![tip14](images/tip14.png)  
-  
-## Insert Normal Mode  
->INM is a special version of Normal mode, which gives us one bullet. We can fire off a single command, after which we'll be returned to Insert mode immediately.  
-  
-## Example  
->`<C-o>zz`: When the current line is right at the top or button of the window, you sometimes want to scroll the screen to see a bit more context. The `zz` command **redraws the screen with the current line in the middle of the window**, which allows us to read **half a screen above and below** the line we're working on.  
-  
+# Tip14: Get Back to Normal Mode
+
+![tip14](images/tip14.png)
+
+## Insert Normal Mode
+>INM is a special version of Normal mode, which gives us one bullet. We can fire off a single command, after which we'll be returned to Insert mode immediately.
+
+## Example
+>`<C-o>zz`: When the current line is right at the top or button of the window, you sometimes want to scroll the screen to see a bit more context. The `zz` command **redraws the screen with the current line in the middle of the window**, which allows us to read **half a screen above and below** the line we're working on.
+
 # [Tip13](tip13.md) [Tip15](tip15.md)

--- a/tip14.md
+++ b/tip14.md
@@ -1,11 +1,11 @@
-#Tip14: Get Back to Normal Mode  
+# Tip14: Get Back to Normal Mode  
    
 ![tip14](images/tip14.png)  
   
-##Insert Normal Mode  
+## Insert Normal Mode  
 >INM is a special version of Normal mode, which gives us one bullet. We can fire off a single command, after which we'll be returned to Insert mode immediately.  
   
-##Example  
+## Example  
 >`<C-o>zz`: When the current line is right at the top or button of the window, you sometimes want to scroll the screen to see a bit more context. The `zz` command **redraws the screen with the current line in the middle of the window**, which allows us to read **half a screen above and below** the line we're working on.  
   
-#[Tip13](tip13.md) [Tip15](tip15.md)
+# [Tip13](tip13.md) [Tip15](tip15.md)

--- a/tip15.md
+++ b/tip15.md
@@ -1,12 +1,12 @@
-#Tip15: Paste from a Register Without Leaving Insert Mode  
+# Tip15: Paste from a Register Without Leaving Insert Mode  
   
 ![tip15](images/tip15.png)  
   
-##yt,  
+## yt,  
 >yank the words **Practical Vim** into the yank register  
   
-##&lt;C-r&gt;0  
+## &lt;C-r&gt;0  
 >`<C-r>{register}`: paste the text that we just yanked at the current cursor position; `<C-r><C-p>{register}`: insert text literally and fix any unintended indentation.  
   
-#[Tip14](tip14.md) [Tip16](tip16.md)  
+# [Tip14](tip14.md) [Tip16](tip16.md)  
 

--- a/tip15.md
+++ b/tip15.md
@@ -1,12 +1,12 @@
-# Tip15: Paste from a Register Without Leaving Insert Mode  
-  
-![tip15](images/tip15.png)  
-  
-## yt,  
->yank the words **Practical Vim** into the yank register  
-  
-## &lt;C-r&gt;0  
->`<C-r>{register}`: paste the text that we just yanked at the current cursor position; `<C-r><C-p>{register}`: insert text literally and fix any unintended indentation.  
-  
-# [Tip14](tip14.md) [Tip16](tip16.md)  
+# Tip15: Paste from a Register Without Leaving Insert Mode
+
+![tip15](images/tip15.png)
+
+## yt,
+>yank the words **Practical Vim** into the yank register
+
+## &lt;C-r&gt;0
+>`<C-r>{register}`: paste the text that we just yanked at the current cursor position; `<C-r><C-p>{register}`: insert text literally and fix any unintended indentation.
+
+# [Tip14](tip14.md) [Tip16](tip16.md)
 

--- a/tip16.md
+++ b/tip16.md
@@ -1,9 +1,9 @@
-#Tip16: Do Back-of-the-Envelope Calculations in Place  
+# Tip16: Do Back-of-the-Envelope Calculations in Place  
   
 **Expression Register**: allows us to perform calculations and then insert the result directly into our document.  
 >`expression register` is addressed by the `=` symbol. From Insert mode we can access it by typing `<C-r>=`: opens a prompt at the bottom of the screen where we can type the expression that we want to evaluate. When done, we hit `<CR>`, and Vim inserts the result at our current position in the document.  
   
 ![tip16](images/tip16.png)  
   
-#[Tip15](tip15.md) [Tip17](tip17.md)
+# [Tip15](tip15.md) [Tip17](tip17.md)
 

--- a/tip16.md
+++ b/tip16.md
@@ -1,9 +1,9 @@
-# Tip16: Do Back-of-the-Envelope Calculations in Place  
-  
-**Expression Register**: allows us to perform calculations and then insert the result directly into our document.  
->`expression register` is addressed by the `=` symbol. From Insert mode we can access it by typing `<C-r>=`: opens a prompt at the bottom of the screen where we can type the expression that we want to evaluate. When done, we hit `<CR>`, and Vim inserts the result at our current position in the document.  
-  
-![tip16](images/tip16.png)  
-  
+# Tip16: Do Back-of-the-Envelope Calculations in Place
+
+**Expression Register**: allows us to perform calculations and then insert the result directly into our document.
+>`expression register` is addressed by the `=` symbol. From Insert mode we can access it by typing `<C-r>=`: opens a prompt at the bottom of the screen where we can type the expression that we want to evaluate. When done, we hit `<CR>`, and Vim inserts the result at our current position in the document.
+
+![tip16](images/tip16.png)
+
 # [Tip15](tip15.md) [Tip17](tip17.md)
 

--- a/tip17.md
+++ b/tip17.md
@@ -1,14 +1,14 @@
-# Tip17: Insert Unusual Characters by Character Code  
-  
+# Tip17: Insert Unusual Characters by Character Code
 
-## &lt;C-v&gt;{code}  
->From Insert mode, entering symbols that are not found on the keyboard. `{code}` is the address of the character that we want to insert.  
-  
-**note**: code consist of three digits! like: `<C-v>065`-->'A' or a four-digit hexadecimal code: `<C-v>u00bf`-->'¿'  
-  
-## ga  
->display the numeric code for any character in your document, just place the cursor on it  
-  
-![tip17](images/tip17.png)  
-  
+
+## &lt;C-v&gt;{code}
+>From Insert mode, entering symbols that are not found on the keyboard. `{code}` is the address of the character that we want to insert.
+
+**note**: code consist of three digits! like: `<C-v>065`-->'A' or a four-digit hexadecimal code: `<C-v>u00bf`-->'¿'
+
+## ga
+>display the numeric code for any character in your document, just place the cursor on it
+
+![tip17](images/tip17.png)
+
 # [Tip16](tip16.md) [Tip18](tip18.md)

--- a/tip17.md
+++ b/tip17.md
@@ -1,14 +1,14 @@
-#Tip17: Insert Unusual Characters by Character Code  
+# Tip17: Insert Unusual Characters by Character Code  
   
 
-##&lt;C-v&gt;{code}  
+## &lt;C-v&gt;{code}  
 >From Insert mode, entering symbols that are not found on the keyboard. `{code}` is the address of the character that we want to insert.  
   
 **note**: code consist of three digits! like: `<C-v>065`-->'A' or a four-digit hexadecimal code: `<C-v>u00bf`-->'¿'  
   
-##ga  
+## ga  
 >display the numeric code for any character in your document, just place the cursor on it  
   
 ![tip17](images/tip17.png)  
   
-#[Tip16](tip16.md) [Tip18](tip18.md)
+# [Tip16](tip16.md) [Tip18](tip18.md)

--- a/tip18.md
+++ b/tip18.md
@@ -1,12 +1,12 @@
-#Tip18: Insert Unusual Characters by Digraph  
+# Tip18: Insert Unusual Characters by Digraph  
   
 **digraph**: pairs of characters that are easy to remember.  
   
-##&lt;C-k&gt;{char1}{char2}  
+## &lt;C-k&gt;{char1}{char2}  
 >From Insert mode, use the digraphs, like: `<C-k>?I`-->'¿'  
   
 **&lt;&lt;**	&lt;&lt;  
 **&gt;&gt;**	&gt;&gt;  
 **½,¼,¾**		12, 14, 34  
   
-#[Tip17](tip17.md) [Tip19](tip19.md)
+# [Tip17](tip17.md) [Tip19](tip19.md)

--- a/tip18.md
+++ b/tip18.md
@@ -1,12 +1,12 @@
-# Tip18: Insert Unusual Characters by Digraph  
-  
-**digraph**: pairs of characters that are easy to remember.  
-  
-## &lt;C-k&gt;{char1}{char2}  
->From Insert mode, use the digraphs, like: `<C-k>?I`-->'¿'  
-  
-**&lt;&lt;**	&lt;&lt;  
-**&gt;&gt;**	&gt;&gt;  
-**½,¼,¾**		12, 14, 34  
-  
+# Tip18: Insert Unusual Characters by Digraph
+
+**digraph**: pairs of characters that are easy to remember.
+
+## &lt;C-k&gt;{char1}{char2}
+>From Insert mode, use the digraphs, like: `<C-k>?I`-->'¿'
+
+**&lt;&lt;**	&lt;&lt;
+**&gt;&gt;**	&gt;&gt;
+**½,¼,¾**		12, 14, 34
+
 # [Tip17](tip17.md) [Tip19](tip19.md)

--- a/tip19.md
+++ b/tip19.md
@@ -1,18 +1,18 @@
-#Tip19: Overwrite Existing Text with Replace Mode  
+# Tip19: Overwrite Existing Text with Replace Mode  
   
 **Replace mode**: is identical to Insert mode, except that it overwrites existing text in the document.  
   
-##R  
+## R  
 >From Normal mode, we can engage Replace mode with `R`, just overwrite the character under the cursor position.  
   
 ![tip19](images/tip19.png)  
   
 **Overwrite Tab Characters with Virtual Replace Mode**  
   
-##gR  
+## gR  
 >goto Virtual Replace Mode and treat the tab character as though it consisted of **spaces**.  
   
-##r{char}, gr{char}  
+## r{char}, gr{char}  
 >overwrite a single character in **Replace** mode and **Virtual Replace** mode.  
   
-#[Tip18](tip18.md) [Tip20](tip20.md)
+# [Tip18](tip18.md) [Tip20](tip20.md)

--- a/tip19.md
+++ b/tip19.md
@@ -1,18 +1,18 @@
-# Tip19: Overwrite Existing Text with Replace Mode  
-  
-**Replace mode**: is identical to Insert mode, except that it overwrites existing text in the document.  
-  
-## R  
->From Normal mode, we can engage Replace mode with `R`, just overwrite the character under the cursor position.  
-  
-![tip19](images/tip19.png)  
-  
-**Overwrite Tab Characters with Virtual Replace Mode**  
-  
-## gR  
->goto Virtual Replace Mode and treat the tab character as though it consisted of **spaces**.  
-  
-## r{char}, gr{char}  
->overwrite a single character in **Replace** mode and **Virtual Replace** mode.  
-  
+# Tip19: Overwrite Existing Text with Replace Mode
+
+**Replace mode**: is identical to Insert mode, except that it overwrites existing text in the document.
+
+## R
+>From Normal mode, we can engage Replace mode with `R`, just overwrite the character under the cursor position.
+
+![tip19](images/tip19.png)
+
+**Overwrite Tab Characters with Virtual Replace Mode**
+
+## gR
+>goto Virtual Replace Mode and treat the tab character as though it consisted of **spaces**.
+
+## r{char}, gr{char}
+>overwrite a single character in **Replace** mode and **Virtual Replace** mode.
+
 # [Tip18](tip18.md) [Tip20](tip20.md)

--- a/tip2.md
+++ b/tip2.md
@@ -1,23 +1,23 @@
-# Tip2: Don't Repeat Yourself  
-  
-## $:  
->move the cursor to the end of the line.  
-  
-## a:  
->append after the current position.  
-  
-## A:  
->append at the end of the current line.(no matter where the cursor is at the time)
-   
-## Example:  
->Goal: append a semicolon at the end of each line  
-  
->$ --> a;Esc for each line.   
->j$. --> for other lines.(. equals a;Esc)  
-  
-# Reduce Extraneous Movement  
->A;Esc --> j. (A instead of $a)      
+# Tip2: Don't Repeat Yourself
 
-![tip2](images/tip2.png)  
-	   
+## $:
+>move the cursor to the end of the line.
+
+## a:
+>append after the current position.
+
+## A:
+>append at the end of the current line.(no matter where the cursor is at the time)
+
+## Example:
+>Goal: append a semicolon at the end of each line
+
+>$ --> a;Esc for each line.
+>j$. --> for other lines.(. equals a;Esc)
+
+# Reduce Extraneous Movement
+>A;Esc --> j. (A instead of $a)
+
+![tip2](images/tip2.png)
+
 # [Tip1](tip1.md) [Tip3](tip3.md)

--- a/tip2.md
+++ b/tip2.md
@@ -1,23 +1,23 @@
-#Tip2: Don't Repeat Yourself  
+# Tip2: Don't Repeat Yourself  
   
-##$:  
+## $:  
 >move the cursor to the end of the line.  
   
-##a:  
+## a:  
 >append after the current position.  
   
-##A:  
+## A:  
 >append at the end of the current line.(no matter where the cursor is at the time)
    
-##Example:  
+## Example:  
 >Goal: append a semicolon at the end of each line  
   
 >$ --> a;Esc for each line.   
 >j$. --> for other lines.(. equals a;Esc)  
   
-#Reduce Extraneous Movement  
+# Reduce Extraneous Movement  
 >A;Esc --> j. (A instead of $a)      
 
 ![tip2](images/tip2.png)  
 	   
-#[Tip1](tip1.md) [Tip3](tip3.md)
+# [Tip1](tip1.md) [Tip3](tip3.md)

--- a/tip20.md
+++ b/tip20.md
@@ -1,16 +1,16 @@
-#Tip20: Grok Visual Mode  
+# Tip20: Grok Visual Mode  
   
 **Visual mode**: allows us to select a range of text and then operate upon it.  
 >Vim has three variants of Visual mode involving working with **characters**, **lines**, **rectangular blocks of text**.  
   
 >Many of the commands that you are familiar with from **Normal mode** work just the same in **Visual mode**.like `h`, `j`, `k`, `l`, `f{char}`  
   
-##viw  
+## viw  
 >From Normal mode, we run `viw` to visually select the word.  
   
-##c  
+## c  
 >`c` command change the selection, deleting the word and dropping us into Insert mode.  
   
 **Select mode**: if we type any printable character in Select mode, it will replace the selection and switch to Insert mode. But **Visual mode** doesn't follow this convention! You should run `c` to delete the selection.  
   
-#[Tip19](tip19.md) [Tip21](tip21.md)
+# [Tip19](tip19.md) [Tip21](tip21.md)

--- a/tip20.md
+++ b/tip20.md
@@ -1,16 +1,16 @@
-# Tip20: Grok Visual Mode  
-  
-**Visual mode**: allows us to select a range of text and then operate upon it.  
->Vim has three variants of Visual mode involving working with **characters**, **lines**, **rectangular blocks of text**.  
-  
->Many of the commands that you are familiar with from **Normal mode** work just the same in **Visual mode**.like `h`, `j`, `k`, `l`, `f{char}`  
-  
-## viw  
->From Normal mode, we run `viw` to visually select the word.  
-  
-## c  
->`c` command change the selection, deleting the word and dropping us into Insert mode.  
-  
-**Select mode**: if we type any printable character in Select mode, it will replace the selection and switch to Insert mode. But **Visual mode** doesn't follow this convention! You should run `c` to delete the selection.  
-  
+# Tip20: Grok Visual Mode
+
+**Visual mode**: allows us to select a range of text and then operate upon it.
+>Vim has three variants of Visual mode involving working with **characters**, **lines**, **rectangular blocks of text**.
+
+>Many of the commands that you are familiar with from **Normal mode** work just the same in **Visual mode**.like `h`, `j`, `k`, `l`, `f{char}`
+
+## viw
+>From Normal mode, we run `viw` to visually select the word.
+
+## c
+>`c` command change the selection, deleting the word and dropping us into Insert mode.
+
+**Select mode**: if we type any printable character in Select mode, it will replace the selection and switch to Insert mode. But **Visual mode** doesn't follow this convention! You should run `c` to delete the selection.
+
 # [Tip19](tip19.md) [Tip21](tip21.md)

--- a/tip21.md
+++ b/tip21.md
@@ -1,21 +1,21 @@
-# Tip21: Define a Visual Selection  
-  
-**character-wise** Visual mode:  
->we can select anything from a single character up to a range of characters within a line or spanning multiple lines. This is suitable for working at the level of individual words or phrases.  
-  
-**line-wise** Visual mode:  
->we can operate on entire lines.  
-  
-**block-wise** Visual mode:  
->allows us to work with columnar regions of the document.  
-  
-# Enabling Visual Modes  
-![tip21](images/tip21.png)  
-  
-# Switching Between Visual Modes  
-![tip21_1](images/tip21_1.png)  
-  
-# Toggling the Free End of a Selection  
-![tip21_2](images/tip21_2.png)  
+# Tip21: Define a Visual Selection
+
+**character-wise** Visual mode:
+>we can select anything from a single character up to a range of characters within a line or spanning multiple lines. This is suitable for working at the level of individual words or phrases.
+
+**line-wise** Visual mode:
+>we can operate on entire lines.
+
+**block-wise** Visual mode:
+>allows us to work with columnar regions of the document.
+
+# Enabling Visual Modes
+![tip21](images/tip21.png)
+
+# Switching Between Visual Modes
+![tip21_1](images/tip21_1.png)
+
+# Toggling the Free End of a Selection
+![tip21_2](images/tip21_2.png)
 
 # [Tip20](tip20.md) [Tip22](tip22.md)

--- a/tip21.md
+++ b/tip21.md
@@ -1,4 +1,4 @@
-#Tip21: Define a Visual Selection  
+# Tip21: Define a Visual Selection  
   
 **character-wise** Visual mode:  
 >we can select anything from a single character up to a range of characters within a line or spanning multiple lines. This is suitable for working at the level of individual words or phrases.  
@@ -9,13 +9,13 @@
 **block-wise** Visual mode:  
 >allows us to work with columnar regions of the document.  
   
-#Enabling Visual Modes  
+# Enabling Visual Modes  
 ![tip21](images/tip21.png)  
   
-#Switching Between Visual Modes  
+# Switching Between Visual Modes  
 ![tip21_1](images/tip21_1.png)  
   
-#Toggling the Free End of a Selection  
+# Toggling the Free End of a Selection  
 ![tip21_2](images/tip21_2.png)  
 
-#[Tip20](tip20.md) [Tip22](tip22.md)
+# [Tip20](tip20.md) [Tip22](tip22.md)

--- a/tip22.md
+++ b/tip22.md
@@ -1,12 +1,12 @@
-#Tip22: Repeat Line-Wise Visual Commands  
+# Tip22: Repeat Line-Wise Visual Commands  
   
-##<  
+## <  
 >indent a tap  
   
-##>  
+## >  
 >unindent a tap  
   
-##example:  
+## example:  
 ![tip22](images/tip22.png)  
   
-#[Tip21](tip21.md) [Tip23](tip23.md)
+# [Tip21](tip21.md) [Tip23](tip23.md)

--- a/tip22.md
+++ b/tip22.md
@@ -1,12 +1,12 @@
-# Tip22: Repeat Line-Wise Visual Commands  
-  
-## <  
->indent a tap  
-  
-## >  
->unindent a tap  
-  
-## example:  
-![tip22](images/tip22.png)  
-  
+# Tip22: Repeat Line-Wise Visual Commands
+
+## <
+>indent a tap
+
+## >
+>unindent a tap
+
+## example:
+![tip22](images/tip22.png)
+
 # [Tip21](tip21.md) [Tip23](tip23.md)

--- a/tip23.md
+++ b/tip23.md
@@ -1,27 +1,27 @@
-#Tip23: Prefer Operators to Visual Commands Where Possible  
+# Tip23: Prefer Operators to Visual Commands Where Possible  
 
 note: Visual mode may be more intuitive than Vim's Normal mode of operation, but it has a weakness: it doesn't always play well with the dot command.  
   
 ![tip23_1](images/tip23_1.png)  
   
-##vit  
+## vit  
 >select the inner contents of a tag  
 >`it` command is a special kind of motion called a text object.  
   
-##U  
+## U  
 >converts the selected characters to uppercase  
   
 Running `j.`:  
 ![tip23_1_1](images/tip23_1_1.png)  
   
-#Tip:  
+# Tip:  
 >The Visual mode `U` command has a Normal mode equivalent: `gU{motion}`    
 
-#Discussion  
+# Discussion  
 >`vitU` can be considered as two separate commands: `vit` to make a selection and `U` to transform the selection.  
 >`gUit` can be considered as a single command comprise of a operator `gU` and a motion `it`.  
   
 ![tip23_2](images/tip23_2.png)  
-##So, we should prefer operator commands over their equivalents when working through a repetitive set of changes.  
+## So, we should prefer operator commands over their equivalents when working through a repetitive set of changes.  
 
-#[Tip22](tip22.md) [Tip24](tip24.md)
+# [Tip22](tip22.md) [Tip24](tip24.md)

--- a/tip23.md
+++ b/tip23.md
@@ -1,27 +1,27 @@
-# Tip23: Prefer Operators to Visual Commands Where Possible  
+# Tip23: Prefer Operators to Visual Commands Where Possible
 
-note: Visual mode may be more intuitive than Vim's Normal mode of operation, but it has a weakness: it doesn't always play well with the dot command.  
-  
-![tip23_1](images/tip23_1.png)  
-  
-## vit  
->select the inner contents of a tag  
->`it` command is a special kind of motion called a text object.  
-  
-## U  
->converts the selected characters to uppercase  
-  
-Running `j.`:  
-![tip23_1_1](images/tip23_1_1.png)  
-  
-# Tip:  
->The Visual mode `U` command has a Normal mode equivalent: `gU{motion}`    
+note: Visual mode may be more intuitive than Vim's Normal mode of operation, but it has a weakness: it doesn't always play well with the dot command.
 
-# Discussion  
->`vitU` can be considered as two separate commands: `vit` to make a selection and `U` to transform the selection.  
->`gUit` can be considered as a single command comprise of a operator `gU` and a motion `it`.  
-  
-![tip23_2](images/tip23_2.png)  
-## So, we should prefer operator commands over their equivalents when working through a repetitive set of changes.  
+![tip23_1](images/tip23_1.png)
+
+## vit
+>select the inner contents of a tag
+>`it` command is a special kind of motion called a text object.
+
+## U
+>converts the selected characters to uppercase
+
+Running `j.`:
+![tip23_1_1](images/tip23_1_1.png)
+
+# Tip:
+>The Visual mode `U` command has a Normal mode equivalent: `gU{motion}`
+
+# Discussion
+>`vitU` can be considered as two separate commands: `vit` to make a selection and `U` to transform the selection.
+>`gUit` can be considered as a single command comprise of a operator `gU` and a motion `it`.
+
+![tip23_2](images/tip23_2.png)
+## So, we should prefer operator commands over their equivalents when working through a repetitive set of changes.
 
 # [Tip22](tip22.md) [Tip24](tip24.md)

--- a/tip24.md
+++ b/tip24.md
@@ -1,23 +1,23 @@
-# Tip24: Edit Tabular Data with Visual-Block Mode  
-  
-## <C-v>3j  
->`<C-v>`: to engage Visual-Block mode; then we define the column selection by moving our cursor down several lines  
+# Tip24: Edit Tabular Data with Visual-Block Mode
 
-## x...  
->`x` key deletes that column, `.` repeats the deletion for the same range of text.  
-  
-## gv  
-> RESELECT our last visual selection  
-  
-## r|  
-> replace each character in the selection with a pipe character.  
-  
-## yyp  
-> we do a quick line-wise yank-and-put to duplicate the top line.  
-  
-## Vr-  
-> replace every character in that line with a dash character.  
-  
-![tip24](images/tip24.png)  
-  
+## <C-v>3j
+>`<C-v>`: to engage Visual-Block mode; then we define the column selection by moving our cursor down several lines
+
+## x...
+>`x` key deletes that column, `.` repeats the deletion for the same range of text.
+
+## gv
+> RESELECT our last visual selection
+
+## r|
+> replace each character in the selection with a pipe character.
+
+## yyp
+> we do a quick line-wise yank-and-put to duplicate the top line.
+
+## Vr-
+> replace every character in that line with a dash character.
+
+![tip24](images/tip24.png)
+
 # [Tip23](tip23.md) [Tip25](tip25.md)

--- a/tip24.md
+++ b/tip24.md
@@ -1,23 +1,23 @@
-#Tip24: Edit Tabular Data with Visual-Block Mode  
+# Tip24: Edit Tabular Data with Visual-Block Mode  
   
-##<C-v>3j  
+## <C-v>3j  
 >`<C-v>`: to engage Visual-Block mode; then we define the column selection by moving our cursor down several lines  
 
-##x...  
+## x...  
 >`x` key deletes that column, `.` repeats the deletion for the same range of text.  
   
-##gv  
+## gv  
 > RESELECT our last visual selection  
   
-##r|  
+## r|  
 > replace each character in the selection with a pipe character.  
   
-##yyp  
+## yyp  
 > we do a quick line-wise yank-and-put to duplicate the top line.  
   
-##Vr-  
+## Vr-  
 > replace every character in that line with a dash character.  
   
 ![tip24](images/tip24.png)  
   
-#[Tip23](tip23.md) [Tip25](tip25.md)
+# [Tip23](tip23.md) [Tip25](tip25.md)

--- a/tip25.md
+++ b/tip25.md
@@ -1,13 +1,13 @@
-# Tip25: Change Columns of Text  
-  
-note: images => components  
-  
-## c  
->all of the selected text disappears and we are dropped into Insert Mode  
-  
-## Esc  
->display other effects  
-  
-![tip25](images/tip25.png)  
-  
+# Tip25: Change Columns of Text
+
+note: images => components
+
+## c
+>all of the selected text disappears and we are dropped into Insert Mode
+
+## Esc
+>display other effects
+
+![tip25](images/tip25.png)
+
 # [Tip24](tip24.md) [Tip26](tip26.md)

--- a/tip25.md
+++ b/tip25.md
@@ -1,13 +1,13 @@
-#Tip25: Change Columns of Text  
+# Tip25: Change Columns of Text  
   
 note: images => components  
   
-##c  
+## c  
 >all of the selected text disappears and we are dropped into Insert Mode  
   
-##Esc  
+## Esc  
 >display other effects  
   
 ![tip25](images/tip25.png)  
   
-#[Tip24](tip24.md) [Tip26](tip26.md)
+# [Tip24](tip24.md) [Tip26](tip26.md)

--- a/tip26.md
+++ b/tip26.md
@@ -1,8 +1,8 @@
-#Tip26:Append After a Ragged Visual Block  
+# Tip26:Append After a Ragged Visual Block  
   
-##$  
+## $  
 >In Visual-Block mode, extend our selection to the end of each line.  
   
 ![tip26](images/tip26.png)  
   
-#[<<Tip25](tip25.md) [Tip27>>](tip27.md)
+# [<<Tip25](tip25.md) [Tip27>>](tip27.md)

--- a/tip26.md
+++ b/tip26.md
@@ -1,8 +1,8 @@
-# Tip26:Append After a Ragged Visual Block  
-  
-## $  
->In Visual-Block mode, extend our selection to the end of each line.  
-  
-![tip26](images/tip26.png)  
-  
+# Tip26:Append After a Ragged Visual Block
+
+## $
+>In Visual-Block mode, extend our selection to the end of each line.
+
+![tip26](images/tip26.png)
+
 # [<<Tip25](tip25.md) [Tip27>>](tip27.md)

--- a/tip27.md
+++ b/tip27.md
@@ -1,22 +1,22 @@
-# Tip27: Meet Vim's Command Line  
-  
-## :  
->switch into Command-Line mode.  
-  
-![tip27](images/tip27.png)  
-  
-## :h ex-cmd-index  
->command list  
-  
-## :&lt;C-w&gt; &lt;C-u&gt; (Insert || Command-Line)  
->delete backward to the strong1art of the **previous word**  
->delete backward to the start of the **line**  
-  
-## :&lt;C-v&gt; &lt;C-k&gt;  
->insert characters that are not found on the keyboard.  
-  
-## :&lt;C-r&gt;{register}  
->insert thate contents of any register at the command line.  
-  
+# Tip27: Meet Vim's Command Line
+
+## :
+>switch into Command-Line mode.
+
+![tip27](images/tip27.png)
+
+## :h ex-cmd-index
+>command list
+
+## :&lt;C-w&gt; &lt;C-u&gt; (Insert || Command-Line)
+>delete backward to the strong1art of the **previous word**
+>delete backward to the start of the **line**
+
+## :&lt;C-v&gt; &lt;C-k&gt;
+>insert characters that are not found on the keyboard.
+
+## :&lt;C-r&gt;{register}
+>insert thate contents of any register at the command line.
+
 
 # [Tip26](tip26.md) [Tip28](tip28.md)

--- a/tip27.md
+++ b/tip27.md
@@ -1,22 +1,22 @@
-#Tip27: Meet Vim's Command Line  
+# Tip27: Meet Vim's Command Line  
   
-##:  
+## :  
 >switch into Command-Line mode.  
   
 ![tip27](images/tip27.png)  
   
-##:h ex-cmd-index  
+## :h ex-cmd-index  
 >command list  
   
-##:&lt;C-w&gt; &lt;C-u&gt; (Insert || Command-Line)  
+## :&lt;C-w&gt; &lt;C-u&gt; (Insert || Command-Line)  
 >delete backward to the strong1art of the **previous word**  
 >delete backward to the start of the **line**  
   
-##:&lt;C-v&gt; &lt;C-k&gt;  
+## :&lt;C-v&gt; &lt;C-k&gt;  
 >insert characters that are not found on the keyboard.  
   
-##:&lt;C-r&gt;{register}  
+## :&lt;C-r&gt;{register}  
 >insert thate contents of any register at the command line.  
   
 
-#[Tip26](tip26.md) [Tip28](tip28.md)
+# [Tip26](tip26.md) [Tip28](tip28.md)

--- a/tip28.md
+++ b/tip28.md
@@ -1,57 +1,57 @@
-# Tip28: Execute a Command on One or More Consecutive Lines  
-    
-![tip28_1](images/tip28_1.png)  
-## :print  
->echo the specified lines below Vim's command line.  
-  
-## :digit (:1)  
->move cursor to the specified line.  
-  
-## :$  
->move cursor to the end line of the file.  
-  
-## :3p  
->move cursor to line 3 and echo the content of that line.  
-  
-## :3d  (3G dd)  
->jump to line 3 and delete it.  
-  
-  
+# Tip28: Execute a Command on One or More Consecutive Lines
+
+![tip28_1](images/tip28_1.png)
+## :print
+>echo the specified lines below Vim's command line.
+
+## :digit (:1)
+>move cursor to the specified line.
+
+## :$
+>move cursor to the end line of the file.
+
+## :3p
+>move cursor to line 3 and echo the content of that line.
+
+## :3d  (3G dd)
+>jump to line 3 and delete it.
+
+
 ## :2,5p  (:{start},{end})
->print each line from 2 to 5. and cursor would be left positioned on line 5.  
-  
-## .  
->represent current line.  
-  
-## :%p  
->`%`: represent all the lines in the current file.  
-  
-## :%s/old/new/  
->replace the first occurrence of 'old' with 'new' on each line.  
-  
-  
-## 2G VG  
->make a visual selection  
->if we press the `:` key, the command-line prompt will be prepopulated with the range `:'<,'>`: stand for the visual selection.  
->and if you press `:'<,'>p`: will print the selection!  
-  
-## '&lt;  
->standing for the first line of the visual selection.  
+>print each line from 2 to 5. and cursor would be left positioned on line 5.
 
-## '&gt;  
->standing for the last line of the visual selection.  
-  
-  
-## :/&lt;html&gt;/,/&lt;\/html&gt;/p  (:{start},{end})  
->print the tags.  
-  
+## .
+>represent current line.
+
+## :%p
+>`%`: represent all the lines in the current file.
+
+## :%s/old/new/
+>replace the first occurrence of 'old' with 'new' on each line.
+
+
+## 2G VG
+>make a visual selection
+>if we press the `:` key, the command-line prompt will be prepopulated with the range `:'<,'>`: stand for the visual selection.
+>and if you press `:'<,'>p`: will print the selection!
+
+## '&lt;
+>standing for the first line of the visual selection.
+
+## '&gt;
+>standing for the last line of the visual selection.
+
+
+## :/&lt;html&gt;/,/&lt;\/html&gt;/p  (:{start},{end})
+>print the tags.
+
 ## :/&lt;html&gt;/+1,/&lt;\/html&gt;/-1p  (:{address}+n)
->print the content of the tag except the tag!  
->if `n` is omitted, it defaults to 1.  
-  
-## :2 && :.,.+3p
->equals to `:2,5p`  
+>print the content of the tag except the tag!
+>if `n` is omitted, it defaults to 1.
 
-![tip28_2](images/tip28_2.png)  
-  
+## :2 && :.,.+3p
+>equals to `:2,5p`
+
+![tip28_2](images/tip28_2.png)
+
 # [Tip27](tip27.md) [Tip29](tip29.md)

--- a/tip28.md
+++ b/tip28.md
@@ -1,57 +1,57 @@
-#Tip28: Execute a Command on One or More Consecutive Lines  
+# Tip28: Execute a Command on One or More Consecutive Lines  
     
 ![tip28_1](images/tip28_1.png)  
-##:print  
+## :print  
 >echo the specified lines below Vim's command line.  
   
-##:digit (:1)  
+## :digit (:1)  
 >move cursor to the specified line.  
   
-##:$  
+## :$  
 >move cursor to the end line of the file.  
   
-##:3p  
+## :3p  
 >move cursor to line 3 and echo the content of that line.  
   
-##:3d  (3G dd)  
+## :3d  (3G dd)  
 >jump to line 3 and delete it.  
   
   
-##:2,5p  (:{start},{end})
+## :2,5p  (:{start},{end})
 >print each line from 2 to 5. and cursor would be left positioned on line 5.  
   
-##.  
+## .  
 >represent current line.  
   
-##:%p  
+## :%p  
 >`%`: represent all the lines in the current file.  
   
-##:%s/old/new/  
+## :%s/old/new/  
 >replace the first occurrence of 'old' with 'new' on each line.  
   
   
-##2G VG  
+## 2G VG  
 >make a visual selection  
 >if we press the `:` key, the command-line prompt will be prepopulated with the range `:'<,'>`: stand for the visual selection.  
 >and if you press `:'<,'>p`: will print the selection!  
   
-##'&lt;  
+## '&lt;  
 >standing for the first line of the visual selection.  
 
-##'&gt;  
+## '&gt;  
 >standing for the last line of the visual selection.  
   
   
-##:/&lt;html&gt;/,/&lt;\/html&gt;/p  (:{start},{end})  
+## :/&lt;html&gt;/,/&lt;\/html&gt;/p  (:{start},{end})  
 >print the tags.  
   
-##:/&lt;html&gt;/+1,/&lt;\/html&gt;/-1p  (:{address}+n)
+## :/&lt;html&gt;/+1,/&lt;\/html&gt;/-1p  (:{address}+n)
 >print the content of the tag except the tag!  
 >if `n` is omitted, it defaults to 1.  
   
-##:2 && :.,.+3p
+## :2 && :.,.+3p
 >equals to `:2,5p`  
 
 ![tip28_2](images/tip28_2.png)  
   
-#[Tip27](tip27.md) [Tip29](tip29.md)
+# [Tip27](tip27.md) [Tip29](tip29.md)

--- a/tip29.md
+++ b/tip29.md
@@ -1,8 +1,8 @@
-#Tip29: Duplicate or Move Lines Using ':t' and ':m' Commands  
+# Tip29: Duplicate or Move Lines Using ':t' and ':m' Commands  
   
 ![tip29_1](images/tip29_1.png)  
   
-##:copy :co :t  (:[range]copy{address})  
+## :copy :co :t  (:[range]copy{address})  
 >duplicate one or more lines from one part of the document to another.  
   
 ![tip29_2](images/tip29_2.png)  
@@ -15,12 +15,12 @@ Note: `:t.`, `yyp`: duplicate the current line. but:
 >`yyp`: use a register.(Normal Mode)  
   
       
-##:move :m (:[range]move {address})  
+## :move :m (:[range]move {address})  
 ![tip29_4](images/tip29_4.png)  
   
-##dGp replace :'&lt;,'&gt;m$  
+## dGp replace :'&lt;,'&gt;m$  
 >`d`: to delete the visual selection.  
 >`G`: to jump to the end of the file.  
 >`p`: to paste the text that was deleted.  
   
-#[Tip28](tip28.md) [Tip30](tip30.md)
+# [Tip28](tip28.md) [Tip30](tip30.md)

--- a/tip29.md
+++ b/tip29.md
@@ -1,26 +1,26 @@
-# Tip29: Duplicate or Move Lines Using ':t' and ':m' Commands  
-  
-![tip29_1](images/tip29_1.png)  
-  
-## :copy :co :t  (:[range]copy{address})  
->duplicate one or more lines from one part of the document to another.  
-  
-![tip29_2](images/tip29_2.png)  
-make a copy of line 6 and put it below the current line.  
-  
-![tip29_3](images/tip29_3.png)  
-  
-Note: `:t.`, `yyp`: duplicate the current line. but:  
->`:t.`: does not use register.(Command-Line Mode)  
->`yyp`: use a register.(Normal Mode)  
-  
-      
-## :move :m (:[range]move {address})  
-![tip29_4](images/tip29_4.png)  
-  
-## dGp replace :'&lt;,'&gt;m$  
->`d`: to delete the visual selection.  
->`G`: to jump to the end of the file.  
->`p`: to paste the text that was deleted.  
-  
+# Tip29: Duplicate or Move Lines Using ':t' and ':m' Commands
+
+![tip29_1](images/tip29_1.png)
+
+## :copy :co :t  (:[range]copy{address})
+>duplicate one or more lines from one part of the document to another.
+
+![tip29_2](images/tip29_2.png)
+make a copy of line 6 and put it below the current line.
+
+![tip29_3](images/tip29_3.png)
+
+Note: `:t.`, `yyp`: duplicate the current line. but:
+>`:t.`: does not use register.(Command-Line Mode)
+>`yyp`: use a register.(Normal Mode)
+
+
+## :move :m (:[range]move {address})
+![tip29_4](images/tip29_4.png)
+
+## dGp replace :'&lt;,'&gt;m$
+>`d`: to delete the visual selection.
+>`G`: to jump to the end of the file.
+>`p`: to paste the text that was deleted.
+
 # [Tip28](tip28.md) [Tip30](tip30.md)

--- a/tip3.md
+++ b/tip3.md
@@ -1,14 +1,14 @@
-#Tip3: Take One Step Back, Then Three Forward  
+# Tip3: Take One Step Back, Then Three Forward  
   
-##f{char}     
+## f{char}     
 >look ahead for the next occurrence of the specified character and move cursor directly to it.  
   
-##s     
+## s     
 >delete the character under the cursor and then enter Insert mode.  
   
-##;    
+## ;    
 >repeat the last search that the **f** command performed.  
    
-#Example  
+# Example  
 ![tip3](images/tip3.png)  
-#[Tip2](tip2.md)    [Tip4](tip4.md)
+# [Tip2](tip2.md)    [Tip4](tip4.md)

--- a/tip3.md
+++ b/tip3.md
@@ -1,14 +1,14 @@
-# Tip3: Take One Step Back, Then Three Forward  
-  
-## f{char}     
->look ahead for the next occurrence of the specified character and move cursor directly to it.  
-  
-## s     
->delete the character under the cursor and then enter Insert mode.  
-  
-## ;    
->repeat the last search that the **f** command performed.  
-   
-# Example  
-![tip3](images/tip3.png)  
+# Tip3: Take One Step Back, Then Three Forward
+
+## f{char}
+>look ahead for the next occurrence of the specified character and move cursor directly to it.
+
+## s
+>delete the character under the cursor and then enter Insert mode.
+
+## ;
+>repeat the last search that the **f** command performed.
+
+# Example
+![tip3](images/tip3.png)
 # [Tip2](tip2.md)    [Tip4](tip4.md)

--- a/tip30.md
+++ b/tip30.md
@@ -1,18 +1,18 @@
-# Tip30: Run Normal Mode Commands Across a Range  
-  
-## :normal  
->run a Normal mode command on a series of consecutive lines.  
-  
-![tip30_1](images/tip30_1.png)  
-![tip30_2](images/tip30_2.png)  
-      
-Note: we can use :normal to execute any Normal mode commands.  
-  
-  
-## :%normal A;  
->append a semicolon at the end of every line of the file.  
-  
-## :%normal i//  
->comment out an entire file.  
-  
+# Tip30: Run Normal Mode Commands Across a Range
+
+## :normal
+>run a Normal mode command on a series of consecutive lines.
+
+![tip30_1](images/tip30_1.png)
+![tip30_2](images/tip30_2.png)
+
+Note: we can use :normal to execute any Normal mode commands.
+
+
+## :%normal A;
+>append a semicolon at the end of every line of the file.
+
+## :%normal i//
+>comment out an entire file.
+
 # [Tip29](tip29.md) [Tip31](tip31.md)

--- a/tip30.md
+++ b/tip30.md
@@ -1,6 +1,6 @@
-#Tip30: Run Normal Mode Commands Across a Range  
+# Tip30: Run Normal Mode Commands Across a Range  
   
-##:normal  
+## :normal  
 >run a Normal mode command on a series of consecutive lines.  
   
 ![tip30_1](images/tip30_1.png)  
@@ -9,10 +9,10 @@
 Note: we can use :normal to execute any Normal mode commands.  
   
   
-##:%normal A;  
+## :%normal A;  
 >append a semicolon at the end of every line of the file.  
   
-##:%normal i//  
+## :%normal i//  
 >comment out an entire file.  
   
-#[Tip29](tip29.md) [Tip31](tip31.md)
+# [Tip29](tip29.md) [Tip31](tip31.md)

--- a/tip31.md
+++ b/tip31.md
@@ -1,19 +1,19 @@
-#Tip31: Repeat the Last Ex Command  
+# Tip31: Repeat the Last Ex Command  
   
-##:@:  
+## :@:  
 >repeat the last Ex command.  
   
-##:@@  
+## :@@  
 >after running `:@:` first time, we can repeat it with `:@@` command.  
   
-##:bn[ext]  
+## :bn[ext]  
 >step forward through the buffer list.  
   
-##:bp[revious]  
+## :bp[revious]  
 >go backward command.  
   
-##&lt;C-o&gt;  
+## &lt;C-o&gt;  
 >each time `:bnext` will adds a record to the jump list.  
 >`<C-o>` goes back to the previous record in the jump list.  
   
-#[Tip30](tip30.md) [Tip32](tip32.md)
+# [Tip30](tip30.md) [Tip32](tip32.md)

--- a/tip31.md
+++ b/tip31.md
@@ -1,19 +1,19 @@
-# Tip31: Repeat the Last Ex Command  
-  
-## :@:  
->repeat the last Ex command.  
-  
-## :@@  
->after running `:@:` first time, we can repeat it with `:@@` command.  
-  
-## :bn[ext]  
->step forward through the buffer list.  
-  
-## :bp[revious]  
->go backward command.  
-  
-## &lt;C-o&gt;  
->each time `:bnext` will adds a record to the jump list.  
->`<C-o>` goes back to the previous record in the jump list.  
-  
+# Tip31: Repeat the Last Ex Command
+
+## :@:
+>repeat the last Ex command.
+
+## :@@
+>after running `:@:` first time, we can repeat it with `:@@` command.
+
+## :bn[ext]
+>step forward through the buffer list.
+
+## :bp[revious]
+>go backward command.
+
+## &lt;C-o&gt;
+>each time `:bnext` will adds a record to the jump list.
+>`<C-o>` goes back to the previous record in the jump list.
+
 # [Tip30](tip30.md) [Tip32](tip32.md)

--- a/tip32.md
+++ b/tip32.md
@@ -1,6 +1,6 @@
-#Tip32: Tab-Complete Your Ex Commands  
+# Tip32: Tab-Complete Your Ex Commands  
   
-##:col&lt;C-d&gt;  
+## :col&lt;C-d&gt;  
 >reveal a list of possible completions  
 >`<Tab>` to cycle through the list  
 >`<S-Tab>` to scroll backward  
@@ -8,10 +8,10 @@
 ![tip32_1](images/tip32_1.png)  
       
   
-##scroll forward  
+## scroll forward  
 >`<Tab>`, `<C-n>`, `<Right>`  
   
-##scroll backward  
+## scroll backward  
 >`<S-Tab>`, `<C-p>`, `<Left>`  
   
-#[Tip31](tip31.md) [Tip33](tip33.md)
+# [Tip31](tip31.md) [Tip33](tip33.md)

--- a/tip32.md
+++ b/tip32.md
@@ -1,17 +1,17 @@
-# Tip32: Tab-Complete Your Ex Commands  
-  
-## :col&lt;C-d&gt;  
->reveal a list of possible completions  
->`<Tab>` to cycle through the list  
->`<S-Tab>` to scroll backward  
-  
-![tip32_1](images/tip32_1.png)  
-      
-  
-## scroll forward  
->`<Tab>`, `<C-n>`, `<Right>`  
-  
-## scroll backward  
->`<S-Tab>`, `<C-p>`, `<Left>`  
-  
+# Tip32: Tab-Complete Your Ex Commands
+
+## :col&lt;C-d&gt;
+>reveal a list of possible completions
+>`<Tab>` to cycle through the list
+>`<S-Tab>` to scroll backward
+
+![tip32_1](images/tip32_1.png)
+
+
+## scroll forward
+>`<Tab>`, `<C-n>`, `<Right>`
+
+## scroll backward
+>`<S-Tab>`, `<C-p>`, `<Left>`
+
 # [Tip31](tip31.md) [Tip33](tip33.md)

--- a/tip33.md
+++ b/tip33.md
@@ -1,15 +1,15 @@
-# Tip33: Insert the Current Word at the Command Prompt  
-  
-## &lt;C-r&gt;&lt;C-w&gt;  
->copy the word under the cursor and insert it at the command-line prompt.  
-  
-## *  
->search for each occurrence that cursor positioned. and cursor jump forward to the next match.  
->equal to typing `/\<<C-r><C-w>\><CR>`  
-  
-![tip33](images/tip33.png)  
-      
-## :%s//&lt;C-r&gt;&lt;C-w&gt;/g  
->replace the others.  
-  
+# Tip33: Insert the Current Word at the Command Prompt
+
+## &lt;C-r&gt;&lt;C-w&gt;
+>copy the word under the cursor and insert it at the command-line prompt.
+
+## *
+>search for each occurrence that cursor positioned. and cursor jump forward to the next match.
+>equal to typing `/\<<C-r><C-w>\><CR>`
+
+![tip33](images/tip33.png)
+
+## :%s//&lt;C-r&gt;&lt;C-w&gt;/g
+>replace the others.
+
 # [Tip32](tip32.md) [Tip34](tip34.md)

--- a/tip33.md
+++ b/tip33.md
@@ -1,15 +1,15 @@
-#Tip33: Insert the Current Word at the Command Prompt  
+# Tip33: Insert the Current Word at the Command Prompt  
   
-##&lt;C-r&gt;&lt;C-w&gt;  
+## &lt;C-r&gt;&lt;C-w&gt;  
 >copy the word under the cursor and insert it at the command-line prompt.  
   
-##*  
+## *  
 >search for each occurrence that cursor positioned. and cursor jump forward to the next match.  
 >equal to typing `/\<<C-r><C-w>\><CR>`  
   
 ![tip33](images/tip33.png)  
       
-##:%s//&lt;C-r&gt;&lt;C-w&gt;/g  
+## :%s//&lt;C-r&gt;&lt;C-w&gt;/g  
 >replace the others.  
   
-#[Tip32](tip32.md) [Tip34](tip34.md)
+# [Tip32](tip32.md) [Tip34](tip34.md)

--- a/tip34.md
+++ b/tip34.md
@@ -1,42 +1,42 @@
-# Tip34: Recall Commands from History  
-  
-Vim records the commands that we enter in Command-Line mode and provides two ways of recalling them:  
->1. scrolling through past command-lines with the cursor keys.  
->2. dialing up the command-line window.  
-  
-**: switch to Command-Line mode**  
-  
-## &lt;UP&gt; &lt;DOWN&gt;  
->previous and next Ex command  
+# Tip34: Recall Commands from History
+
+Vim records the commands that we enter in Command-Line mode and provides two ways of recalling them:
+>1. scrolling through past command-lines with the cursor keys.
+>2. dialing up the command-line window.
+
+**: switch to Command-Line mode**
+
+## &lt;UP&gt; &lt;DOWN&gt;
+>previous and next Ex command
 >**can filter the command by pretype: `:co`**
-  
-## &lt;C-p&gt; &lt;C-n&gt;  
->previous and next Ex comand  
->**can not filter the command, just previous and next comand**  
-  
-Note: By default, Vim records the last twenty commands, you can set by : `set history=200` in vimrc.  
-  
-**/ switch to search prompt**  
->all keys can use like before.  
-  
-  
-**Meet the Command-Line Window**  
-  
-Note: Avoid the Cursor Keys When Recalling Commands from History.  
-you can create the mapping:  
->cnoremap &lt;C-p&gt; &lt;Up&gt;  
->cnoremap &lt;C-n&gt; &lt;Down&gt;  
-  
-## q: (Normal mode)  
->meet the command-line window.   
-  
-Note: The Command-Line window is like a regular Vim buffer, where each line contains an item from our history. `h, j, k, l` can use,  when you press the &lt;CR&gt; key, the contents of the current line are executed as an Ex command.  
-  
-## merge the command  
-![tip34_1](images/tip34_1.png)  
-  
-Press &lt;CR&gt; to execute the `:update | !ruby %` command.  
-  
-![tip34_2](images/tip34_2.png)  
-      
+
+## &lt;C-p&gt; &lt;C-n&gt;
+>previous and next Ex comand
+>**can not filter the command, just previous and next comand**
+
+Note: By default, Vim records the last twenty commands, you can set by : `set history=200` in vimrc.
+
+**/ switch to search prompt**
+>all keys can use like before.
+
+
+**Meet the Command-Line Window**
+
+Note: Avoid the Cursor Keys When Recalling Commands from History.
+you can create the mapping:
+>cnoremap &lt;C-p&gt; &lt;Up&gt;
+>cnoremap &lt;C-n&gt; &lt;Down&gt;
+
+## q: (Normal mode)
+>meet the command-line window.
+
+Note: The Command-Line window is like a regular Vim buffer, where each line contains an item from our history. `h, j, k, l` can use,  when you press the &lt;CR&gt; key, the contents of the current line are executed as an Ex command.
+
+## merge the command
+![tip34_1](images/tip34_1.png)
+
+Press &lt;CR&gt; to execute the `:update | !ruby %` command.
+
+![tip34_2](images/tip34_2.png)
+
 # [Tip33](tip33.md) [Tip35](tip35.md)

--- a/tip34.md
+++ b/tip34.md
@@ -1,4 +1,4 @@
-#Tip34: Recall Commands from History  
+# Tip34: Recall Commands from History  
   
 Vim records the commands that we enter in Command-Line mode and provides two ways of recalling them:  
 >1. scrolling through past command-lines with the cursor keys.  
@@ -6,11 +6,11 @@ Vim records the commands that we enter in Command-Line mode and provides two way
   
 **: switch to Command-Line mode**  
   
-##&lt;UP&gt; &lt;DOWN&gt;  
+## &lt;UP&gt; &lt;DOWN&gt;  
 >previous and next Ex command  
 >**can filter the command by pretype: `:co`**
   
-##&lt;C-p&gt; &lt;C-n&gt;  
+## &lt;C-p&gt; &lt;C-n&gt;  
 >previous and next Ex comand  
 >**can not filter the command, just previous and next comand**  
   
@@ -27,16 +27,16 @@ you can create the mapping:
 >cnoremap &lt;C-p&gt; &lt;Up&gt;  
 >cnoremap &lt;C-n&gt; &lt;Down&gt;  
   
-##q: (Normal mode)  
+## q: (Normal mode)  
 >meet the command-line window.   
   
 Note: The Command-Line window is like a regular Vim buffer, where each line contains an item from our history. `h, j, k, l` can use,  when you press the &lt;CR&gt; key, the contents of the current line are executed as an Ex command.  
   
-##merge the command  
+## merge the command  
 ![tip34_1](images/tip34_1.png)  
   
 Press &lt;CR&gt; to execute the `:update | !ruby %` command.  
   
 ![tip34_2](images/tip34_2.png)  
       
-#[Tip33](tip33.md) [Tip35](tip35.md)
+# [Tip33](tip33.md) [Tip35](tip35.md)

--- a/tip35.md
+++ b/tip35.md
@@ -1,64 +1,64 @@
-# Tip35: Run Commands in the Shell  
-  
-**Executing Programs in the Shell**  
-  
-## :!ls (:!{cmd})  
->call `ls` in the current directory.  
->**This is one-off command**  
-  
-## :ls  
->call Vim's built-in command, shows the contents of the buffer list.  
-  
-## % (Command-Line)  
->this `%` symbol is shorthand for the current file name.  
-  
-## :!ruby %  
->if we're working on a Ruby file, we can execute it by this.  
-  
-## :shell  
->start an interactive shell session. you can execute several commands.  
-  
-![tip35_1](images/tip35_1.png)  
-      
-## &lt;C-z&gt;  
->suspend the process that's running Vim and return control to bash.  
-  
-##  ($) jobs  
->list the jobs.  
-  
-##  ($) fg  
->resume a suspended job, bringing it back into the foreground.  
-  
-**Using the Contents of a Buffer for Standard Input or Output**  
-  
-## :read !{cmd}  
->put the output from the {cmd} into our current buffer.  
-  
-## :write !{cmd}  
->use the contents of the buffer as standard input for the specified {cmd}  
-  
->`:write !sh`, `:write ! sh`: pass the contents of the buffer as standard input to the sh command.  
->`:write! sh`: write the contents of the buffer to a file called sh.  
-  
-  
-**Filtering the Contents of a Buffer Through an External Command**  
-  
-## :[range]!{cmd/filter}  
->[range]: The lines specified by [range] are passed as standard input for the {comd}, and then the output from {cmd} overwrites the original contents of [range]. or to put it another way.  
-  
-![tip35_2](images/tip35_2.png)  
-  
-## :2,$!sort -t',' -k2  
->`-t','`: tell the sort command that fields are separated with commas.  
->`-k2`: to indicate that the second field is to be used for the sort.  
-  
-## !{motion}  
->drop us into Command-Line mode and prepopulates the [range] with the liens covered by the specified {motion}.  
-  
-## !G  (:.,$!)  
->place cursor on line 2 and invoke `!G`, vim opens a prompt with the `:.,$!` range set up for us.  
-  
-  
-![tip35_3](images/tip35_3.png)  
-      
+# Tip35: Run Commands in the Shell
+
+**Executing Programs in the Shell**
+
+## :!ls (:!{cmd})
+>call `ls` in the current directory.
+>**This is one-off command**
+
+## :ls
+>call Vim's built-in command, shows the contents of the buffer list.
+
+## % (Command-Line)
+>this `%` symbol is shorthand for the current file name.
+
+## :!ruby %
+>if we're working on a Ruby file, we can execute it by this.
+
+## :shell
+>start an interactive shell session. you can execute several commands.
+
+![tip35_1](images/tip35_1.png)
+
+## &lt;C-z&gt;
+>suspend the process that's running Vim and return control to bash.
+
+##  ($) jobs
+>list the jobs.
+
+##  ($) fg
+>resume a suspended job, bringing it back into the foreground.
+
+**Using the Contents of a Buffer for Standard Input or Output**
+
+## :read !{cmd}
+>put the output from the {cmd} into our current buffer.
+
+## :write !{cmd}
+>use the contents of the buffer as standard input for the specified {cmd}
+
+>`:write !sh`, `:write ! sh`: pass the contents of the buffer as standard input to the sh command.
+>`:write! sh`: write the contents of the buffer to a file called sh.
+
+
+**Filtering the Contents of a Buffer Through an External Command**
+
+## :[range]!{cmd/filter}
+>[range]: The lines specified by [range] are passed as standard input for the {comd}, and then the output from {cmd} overwrites the original contents of [range]. or to put it another way.
+
+![tip35_2](images/tip35_2.png)
+
+## :2,$!sort -t',' -k2
+>`-t','`: tell the sort command that fields are separated with commas.
+>`-k2`: to indicate that the second field is to be used for the sort.
+
+## !{motion}
+>drop us into Command-Line mode and prepopulates the [range] with the liens covered by the specified {motion}.
+
+## !G  (:.,$!)
+>place cursor on line 2 and invoke `!G`, vim opens a prompt with the `:.,$!` range set up for us.
+
+
+![tip35_3](images/tip35_3.png)
+
 # [Tip34](tip34.md) [Tip36](tip36.md)

--- a/tip35.md
+++ b/tip35.md
@@ -1,40 +1,40 @@
-#Tip35: Run Commands in the Shell  
+# Tip35: Run Commands in the Shell  
   
 **Executing Programs in the Shell**  
   
-##:!ls (:!{cmd})  
+## :!ls (:!{cmd})  
 >call `ls` in the current directory.  
 >**This is one-off command**  
   
-##:ls  
+## :ls  
 >call Vim's built-in command, shows the contents of the buffer list.  
   
-##% (Command-Line)  
+## % (Command-Line)  
 >this `%` symbol is shorthand for the current file name.  
   
-##:!ruby %  
+## :!ruby %  
 >if we're working on a Ruby file, we can execute it by this.  
   
-##:shell  
+## :shell  
 >start an interactive shell session. you can execute several commands.  
   
 ![tip35_1](images/tip35_1.png)  
       
-##&lt;C-z&gt;  
+## &lt;C-z&gt;  
 >suspend the process that's running Vim and return control to bash.  
   
-## ($) jobs  
+##  ($) jobs  
 >list the jobs.  
   
-## ($) fg  
+##  ($) fg  
 >resume a suspended job, bringing it back into the foreground.  
   
 **Using the Contents of a Buffer for Standard Input or Output**  
   
-##:read !{cmd}  
+## :read !{cmd}  
 >put the output from the {cmd} into our current buffer.  
   
-##:write !{cmd}  
+## :write !{cmd}  
 >use the contents of the buffer as standard input for the specified {cmd}  
   
 >`:write !sh`, `:write ! sh`: pass the contents of the buffer as standard input to the sh command.  
@@ -43,22 +43,22 @@
   
 **Filtering the Contents of a Buffer Through an External Command**  
   
-##:[range]!{cmd/filter}  
+## :[range]!{cmd/filter}  
 >[range]: The lines specified by [range] are passed as standard input for the {comd}, and then the output from {cmd} overwrites the original contents of [range]. or to put it another way.  
   
 ![tip35_2](images/tip35_2.png)  
   
-##:2,$!sort -t',' -k2  
+## :2,$!sort -t',' -k2  
 >`-t','`: tell the sort command that fields are separated with commas.  
 >`-k2`: to indicate that the second field is to be used for the sort.  
   
-##!{motion}  
+## !{motion}  
 >drop us into Command-Line mode and prepopulates the [range] with the liens covered by the specified {motion}.  
   
-##!G  (:.,$!)  
+## !G  (:.,$!)  
 >place cursor on line 2 and invoke `!G`, vim opens a prompt with the `:.,$!` range set up for us.  
   
   
 ![tip35_3](images/tip35_3.png)  
       
-#[Tip34](tip34.md) [Tip36](tip36.md)
+# [Tip34](tip34.md) [Tip36](tip36.md)

--- a/tip36.md
+++ b/tip36.md
@@ -1,67 +1,67 @@
-# Tip36: Track Open Files with the Buffer List  
-  
-We can load multiple files during an editing session. Vim lets us manage them using the **buffer list**.  
-  
-**Understand the Distinction Between Files and Buffers**  
-  
-Vim allows us to read files, edit them, and save our changes. But we are **not** editing a file. Instead, we're editing an **in-memory representation of a file**, which is called **buffer**.  
-  
-**Files** are stored on the disk.  
-**Buffers** exist in memory.  
-When we open a file in vim, its contents are read into a buffer, which takes the same name as the file.  
-  
-Initially, the contents of the buffer will be identical to those of the file, but the two will diverge as we make changes to the buffer.  
-  
-If you decide that you want to keep your changes, you can write the contents of the buffer back into the file.  
-  
-Most vim commands operate on buffers, but a few operate on files, including the `:write`, `:update`, `:saveas` commands.  
-  
-  
-**Meet the Buffer List**  
-  
-Vim allows us to work with multiple buffers simultaneously.  
-`vim *.txt`:  
->`*.txt`: this wildcard matches two files in the current directory: a.txt, b.txt  
->This cmd tells vim to open both of those files.  
->When vim starts up, it shows **a single window** with a buffer representing the first of the two files. The other file **isn't visible**, but it has been loaded into a buffer in the background.  
-  
-![tip36_1](images/tip36_1.png)  
-`:ls`: command gives us a listing of all the buffers that have been loaded into memory.  
-  
-switch to next buffer: `:bnext`  
-![tip36_2](images/tip36_2.png)  
-`%`: indicates which of the buffers is visible in the current window.  
-`#`: represents the alternate file.  
-`<C-^>`: quickly toggle between the current and alternate files.  
-  
-  
-**Use the Buffer List**  
-  
-Traverse the buffer list:  
->`:bprev`: move backward  
->`:bnext`: move forward  
->`:bfirst`: jump to the start of the list  
->`:blast`: jump to the end of the list  
-  
-## :buffer N  
->jump directly to a buffer by number. because `:ls` listing starts with a digit, which is assigned to each buffer automatically on creation.  
-  
-## :buffer {bufname}  
->{bufname} need only contain enough characters from the filepath to uniquely identify the buffer.  
-  
-## :bufdo :argdo  
->execute an Ex command in all of the buffers listed by `:ls`.  
-  
-  
-**Deleting Buffers**  
-  
-## :bd[elete]  
->`:bdelete N1 N2 N3`:  `:bd 5 6 7`  
->`:N,M bdelete`: `:5,10bd`  
-Note: deleting a buffer has no effect on its associated file. it simply removes the in-memory representation.  
-  
-Buffer numbers are automatically assigned by Vim, and we have no means of changing them by hand. So if we want to delete one or more buffers, we first have to look them up to find out their numbers, this is time-consuming, so unless I have a good reason to delete a buffer, I usually don't bother!  
-  
-Note: Vim's built-in controls for managing the buffer list lack flexibility. If we want to arrange buffers in a way that makes sense for our workflow, attempting to organize the buffer list is not the way to go. Instead, we're better off dividing our workspace using **split windows**, **tab pages**, or the **argument list**.  
-  
+# Tip36: Track Open Files with the Buffer List
+
+We can load multiple files during an editing session. Vim lets us manage them using the **buffer list**.
+
+**Understand the Distinction Between Files and Buffers**
+
+Vim allows us to read files, edit them, and save our changes. But we are **not** editing a file. Instead, we're editing an **in-memory representation of a file**, which is called **buffer**.
+
+**Files** are stored on the disk.
+**Buffers** exist in memory.
+When we open a file in vim, its contents are read into a buffer, which takes the same name as the file.
+
+Initially, the contents of the buffer will be identical to those of the file, but the two will diverge as we make changes to the buffer.
+
+If you decide that you want to keep your changes, you can write the contents of the buffer back into the file.
+
+Most vim commands operate on buffers, but a few operate on files, including the `:write`, `:update`, `:saveas` commands.
+
+
+**Meet the Buffer List**
+
+Vim allows us to work with multiple buffers simultaneously.
+`vim *.txt`:
+>`*.txt`: this wildcard matches two files in the current directory: a.txt, b.txt
+>This cmd tells vim to open both of those files.
+>When vim starts up, it shows **a single window** with a buffer representing the first of the two files. The other file **isn't visible**, but it has been loaded into a buffer in the background.
+
+![tip36_1](images/tip36_1.png)
+`:ls`: command gives us a listing of all the buffers that have been loaded into memory.
+
+switch to next buffer: `:bnext`
+![tip36_2](images/tip36_2.png)
+`%`: indicates which of the buffers is visible in the current window.
+`#`: represents the alternate file.
+`<C-^>`: quickly toggle between the current and alternate files.
+
+
+**Use the Buffer List**
+
+Traverse the buffer list:
+>`:bprev`: move backward
+>`:bnext`: move forward
+>`:bfirst`: jump to the start of the list
+>`:blast`: jump to the end of the list
+
+## :buffer N
+>jump directly to a buffer by number. because `:ls` listing starts with a digit, which is assigned to each buffer automatically on creation.
+
+## :buffer {bufname}
+>{bufname} need only contain enough characters from the filepath to uniquely identify the buffer.
+
+## :bufdo :argdo
+>execute an Ex command in all of the buffers listed by `:ls`.
+
+
+**Deleting Buffers**
+
+## :bd[elete]
+>`:bdelete N1 N2 N3`:  `:bd 5 6 7`
+>`:N,M bdelete`: `:5,10bd`
+Note: deleting a buffer has no effect on its associated file. it simply removes the in-memory representation.
+
+Buffer numbers are automatically assigned by Vim, and we have no means of changing them by hand. So if we want to delete one or more buffers, we first have to look them up to find out their numbers, this is time-consuming, so unless I have a good reason to delete a buffer, I usually don't bother!
+
+Note: Vim's built-in controls for managing the buffer list lack flexibility. If we want to arrange buffers in a way that makes sense for our workflow, attempting to organize the buffer list is not the way to go. Instead, we're better off dividing our workspace using **split windows**, **tab pages**, or the **argument list**.
+
 # [Tip35](tip35.md) [Tip37](tip37.md)

--- a/tip36.md
+++ b/tip36.md
@@ -1,4 +1,4 @@
-#Tip36: Track Open Files with the Buffer List  
+# Tip36: Track Open Files with the Buffer List  
   
 We can load multiple files during an editing session. Vim lets us manage them using the **buffer list**.  
   
@@ -43,19 +43,19 @@ Traverse the buffer list:
 >`:bfirst`: jump to the start of the list  
 >`:blast`: jump to the end of the list  
   
-##:buffer N  
+## :buffer N  
 >jump directly to a buffer by number. because `:ls` listing starts with a digit, which is assigned to each buffer automatically on creation.  
   
-##:buffer {bufname}  
+## :buffer {bufname}  
 >{bufname} need only contain enough characters from the filepath to uniquely identify the buffer.  
   
-##:bufdo :argdo  
+## :bufdo :argdo  
 >execute an Ex command in all of the buffers listed by `:ls`.  
   
   
 **Deleting Buffers**  
   
-##:bd[elete]  
+## :bd[elete]  
 >`:bdelete N1 N2 N3`:  `:bd 5 6 7`  
 >`:N,M bdelete`: `:5,10bd`  
 Note: deleting a buffer has no effect on its associated file. it simply removes the in-memory representation.  
@@ -64,4 +64,4 @@ Buffer numbers are automatically assigned by Vim, and we have no means of changi
   
 Note: Vim's built-in controls for managing the buffer list lack flexibility. If we want to arrange buffers in a way that makes sense for our workflow, attempting to organize the buffer list is not the way to go. Instead, we're better off dividing our workspace using **split windows**, **tab pages**, or the **argument list**.  
   
-#[Tip35](tip35.md) [Tip37](tip37.md)
+# [Tip35](tip35.md) [Tip37](tip37.md)

--- a/tip37.md
+++ b/tip37.md
@@ -1,38 +1,38 @@
-# Tip37: Group Buffers into a Collection with the Argument List  
-  
-`vim *.txt` then:  
-![tip37_1](images/tip37_1.png)  
->the **argument list** represents the list of files that was passed as an argument when we ran the vim command.  
->`[]`: indicate which of the files in the argument list is active.  
-  
-**Populate the Argument List**  
->When the `:args` is run without arguments, it prints the contents of the argument list.  
-  
-## :args {arglist}  
->set the contents of the argument list.  
->{arglist} can include filenames, wildcards, or even the output from a shell command.  
-  
-  
-**Specify Files by Name**  
-  
-![tip37_2](images/tip37_2.png)  
-  
-**Specify Files by Glob**  
-  
-## *  
->match zero or more characters, but only in the scope of the specified directory.  
-  
-## **  
->match zero or more characters, but it can recurse downward into directories below the specified directory.  
-  
+# Tip37: Group Buffers into a Collection with the Argument List
+
+`vim *.txt` then:
+![tip37_1](images/tip37_1.png)
+>the **argument list** represents the list of files that was passed as an argument when we ran the vim command.
+>`[]`: indicate which of the files in the argument list is active.
+
+**Populate the Argument List**
+>When the `:args` is run without arguments, it prints the contents of the argument list.
+
+## :args {arglist}
+>set the contents of the argument list.
+>{arglist} can include filenames, wildcards, or even the output from a shell command.
+
+
+**Specify Files by Name**
+
+![tip37_2](images/tip37_2.png)
+
+**Specify Files by Glob**
+
+## *
+>match zero or more characters, but only in the scope of the specified directory.
+
+## **
+>match zero or more characters, but it can recurse downward into directories below the specified directory.
+
 ![tip37_3](images/tip37_3.png)
-  
-## :args **/*.js **/*.css  
->build an argument list containing all .js and .css files but not other file types.  
-  
-  
-**Specify Files by Backtick Expansion**  
-  
-![tip37_4](images/tip37_4.png)  
-  
+
+## :args **/*.js **/*.css
+>build an argument list containing all .js and .css files but not other file types.
+
+
+**Specify Files by Backtick Expansion**
+
+![tip37_4](images/tip37_4.png)
+
 # [Tip36](tip36.md) [Tip38](tip38.md)

--- a/tip37.md
+++ b/tip37.md
@@ -1,4 +1,4 @@
-#Tip37: Group Buffers into a Collection with the Argument List  
+# Tip37: Group Buffers into a Collection with the Argument List  
   
 `vim *.txt` then:  
 ![tip37_1](images/tip37_1.png)  
@@ -8,7 +8,7 @@
 **Populate the Argument List**  
 >When the `:args` is run without arguments, it prints the contents of the argument list.  
   
-##:args {arglist}  
+## :args {arglist}  
 >set the contents of the argument list.  
 >{arglist} can include filenames, wildcards, or even the output from a shell command.  
   
@@ -19,15 +19,15 @@
   
 **Specify Files by Glob**  
   
-##*  
+## *  
 >match zero or more characters, but only in the scope of the specified directory.  
   
-##**  
+## **  
 >match zero or more characters, but it can recurse downward into directories below the specified directory.  
   
 ![tip37_3](images/tip37_3.png)
   
-##:args **/*.js **/*.css  
+## :args **/*.js **/*.css  
 >build an argument list containing all .js and .css files but not other file types.  
   
   
@@ -35,4 +35,4 @@
   
 ![tip37_4](images/tip37_4.png)  
   
-#[Tip36](tip36.md) [Tip38](tip38.md)
+# [Tip36](tip36.md) [Tip38](tip38.md)

--- a/tip38.md
+++ b/tip38.md
@@ -1,37 +1,37 @@
-# Tip38: Manage Hidden Files  
-  
-When a buffer has been modified, Vim gives it special treatment to ensure that we don't accidentally quit the editor without saving our changes, Find out how to hide a modified buffer and how to handle hidden buffers when quiting Vim.  
-  
-![tip38_1](images/tip38_1.png)  
-      
-![tip38_2](images/tip38_2.png)  
-      
-  
-**Handle Hidden Buffers on Quit**  
-  
-When you quit Vim and have unsaved changes in one of buffers. Vim loads the first hidden buffer with modifications into the current window so that we can decide what to do with it.  
-  
-## :write  
-> to save the buffer to a file.  
-  
-## :edit!  
-> to discard the changes(reread the file from disk, overwriting the contents of the buffer)  
-      
-Vim activates the next unsaved buffer each time we enter the `:quit` command  
-  
-## :qall!  
-> quit Vim without reviewing our unsaved changes.  
-  
-## :wall  
-> write all modified buffers without reviewing them one by one.  
-  
-![tip38_3](images/tip38_3.png)  
-      
-  
-**Enable the `hidden` Setting Before Running `:argdo` or `:bufdo`**  
-  
-Be default, Vim prevents us from abandoning a modified buffer.  
-  
-![tip38_4](images/tip38_4.png)  
-      
+# Tip38: Manage Hidden Files
+
+When a buffer has been modified, Vim gives it special treatment to ensure that we don't accidentally quit the editor without saving our changes, Find out how to hide a modified buffer and how to handle hidden buffers when quiting Vim.
+
+![tip38_1](images/tip38_1.png)
+
+![tip38_2](images/tip38_2.png)
+
+
+**Handle Hidden Buffers on Quit**
+
+When you quit Vim and have unsaved changes in one of buffers. Vim loads the first hidden buffer with modifications into the current window so that we can decide what to do with it.
+
+## :write
+> to save the buffer to a file.
+
+## :edit!
+> to discard the changes(reread the file from disk, overwriting the contents of the buffer)
+
+Vim activates the next unsaved buffer each time we enter the `:quit` command
+
+## :qall!
+> quit Vim without reviewing our unsaved changes.
+
+## :wall
+> write all modified buffers without reviewing them one by one.
+
+![tip38_3](images/tip38_3.png)
+
+
+**Enable the `hidden` Setting Before Running `:argdo` or `:bufdo`**
+
+Be default, Vim prevents us from abandoning a modified buffer.
+
+![tip38_4](images/tip38_4.png)
+
 # [Tip37](tip37.md) [Tip39](tip39.md)

--- a/tip38.md
+++ b/tip38.md
@@ -1,4 +1,4 @@
-#Tip38: Manage Hidden Files  
+# Tip38: Manage Hidden Files  
   
 When a buffer has been modified, Vim gives it special treatment to ensure that we don't accidentally quit the editor without saving our changes, Find out how to hide a modified buffer and how to handle hidden buffers when quiting Vim.  
   
@@ -11,18 +11,18 @@ When a buffer has been modified, Vim gives it special treatment to ensure that w
   
 When you quit Vim and have unsaved changes in one of buffers. Vim loads the first hidden buffer with modifications into the current window so that we can decide what to do with it.  
   
-##:write  
+## :write  
 > to save the buffer to a file.  
   
-##:edit!  
+## :edit!  
 > to discard the changes(reread the file from disk, overwriting the contents of the buffer)  
       
 Vim activates the next unsaved buffer each time we enter the `:quit` command  
   
-##:qall!  
+## :qall!  
 > quit Vim without reviewing our unsaved changes.  
   
-##:wall  
+## :wall  
 > write all modified buffers without reviewing them one by one.  
   
 ![tip38_3](images/tip38_3.png)  
@@ -34,4 +34,4 @@ Be default, Vim prevents us from abandoning a modified buffer.
   
 ![tip38_4](images/tip38_4.png)  
       
-#[Tip37](tip37.md) [Tip39](tip39.md)
+# [Tip37](tip37.md) [Tip39](tip39.md)

--- a/tip39.md
+++ b/tip39.md
@@ -1,43 +1,43 @@
-# Tip39: Divide Your Workspace into Split Windows  
-  
-In Vim's terminology, a window is a viewport onto a buffer.  
-We can open multiple windows, each containing the same buffer,  
-or we can load different buffers into each window.  
-  
-## &lt;C-w&gt;s  
->divide window horizontally, which create two windows of equal height.  
-  
-## &lt;C-w&gt;v  
->split window vertically, which produce two windows of equal width.  
-  
-Note: you can repeat these commands as often as you like, splitting your workspace again and again in a process that resembles cell division.  
-  
-![tip39_1](images/tip39_1.png)  
-      
-Note: Each time we use the `<C-w>s` and `<C-w>v` commands, the two resulting split windows will **contain the same buffer** as the original window was divided.  
-  
-## :edit  
->load another buffer into the active window.  
-  
+# Tip39: Divide Your Workspace into Split Windows
+
+In Vim's terminology, a window is a viewport onto a buffer.
+We can open multiple windows, each containing the same buffer,
+or we can load different buffers into each window.
+
+## &lt;C-w&gt;s
+>divide window horizontally, which create two windows of equal height.
+
+## &lt;C-w&gt;v
+>split window vertically, which produce two windows of equal width.
+
+Note: you can repeat these commands as often as you like, splitting your workspace again and again in a process that resembles cell division.
+
+![tip39_1](images/tip39_1.png)
+
+Note: Each time we use the `<C-w>s` and `<C-w>v` commands, the two resulting split windows will **contain the same buffer** as the original window was divided.
+
+## :edit
+>load another buffer into the active window.
+
 ## &lt;C-w&gt;s :edit {filename}  === :split {filename}
->divide our workspace and then open another buffer in one split window while keeping the existing buffer visible in the other split.  
-  
-![tip39_2](images/tip39_2.png)  
-      
-**Changing the Focus Between Windows**  
-![tip39_3](images/tip39_3.png)  
-  
-In fact, `<C-w><C-w>` === `<C-w>w`, you can press the `<Ctrl>` key and hold it while typing `ww`(or `wj` or any others from the table) to change the active window. It's easier to do that.  
-  
-## :close  
->close the active window.  
-  
-## :only  
->close all windows except the active one.  
-  
-![tip39_4](images/tip39_4.png)  
-      
-**Resizing and Rearranging Windows**  
-![tip39_5](images/tip39_5.png)  
-      
+>divide our workspace and then open another buffer in one split window while keeping the existing buffer visible in the other split.
+
+![tip39_2](images/tip39_2.png)
+
+**Changing the Focus Between Windows**
+![tip39_3](images/tip39_3.png)
+
+In fact, `<C-w><C-w>` === `<C-w>w`, you can press the `<Ctrl>` key and hold it while typing `ww`(or `wj` or any others from the table) to change the active window. It's easier to do that.
+
+## :close
+>close the active window.
+
+## :only
+>close all windows except the active one.
+
+![tip39_4](images/tip39_4.png)
+
+**Resizing and Rearranging Windows**
+![tip39_5](images/tip39_5.png)
+
 # [Tip38](tip38.md) [Tip40](tip40.md)

--- a/tip39.md
+++ b/tip39.md
@@ -1,13 +1,13 @@
-#Tip39: Divide Your Workspace into Split Windows  
+# Tip39: Divide Your Workspace into Split Windows  
   
 In Vim's terminology, a window is a viewport onto a buffer.  
 We can open multiple windows, each containing the same buffer,  
 or we can load different buffers into each window.  
   
-##&lt;C-w&gt;s  
+## &lt;C-w&gt;s  
 >divide window horizontally, which create two windows of equal height.  
   
-##&lt;C-w&gt;v  
+## &lt;C-w&gt;v  
 >split window vertically, which produce two windows of equal width.  
   
 Note: you can repeat these commands as often as you like, splitting your workspace again and again in a process that resembles cell division.  
@@ -16,10 +16,10 @@ Note: you can repeat these commands as often as you like, splitting your workspa
       
 Note: Each time we use the `<C-w>s` and `<C-w>v` commands, the two resulting split windows will **contain the same buffer** as the original window was divided.  
   
-##:edit  
+## :edit  
 >load another buffer into the active window.  
   
-##&lt;C-w&gt;s :edit {filename}  === :split {filename}
+## &lt;C-w&gt;s :edit {filename}  === :split {filename}
 >divide our workspace and then open another buffer in one split window while keeping the existing buffer visible in the other split.  
   
 ![tip39_2](images/tip39_2.png)  
@@ -29,10 +29,10 @@ Note: Each time we use the `<C-w>s` and `<C-w>v` commands, the two resulting spl
   
 In fact, `<C-w><C-w>` === `<C-w>w`, you can press the `<Ctrl>` key and hold it while typing `ww`(or `wj` or any others from the table) to change the active window. It's easier to do that.  
   
-##:close  
+## :close  
 >close the active window.  
   
-##:only  
+## :only  
 >close all windows except the active one.  
   
 ![tip39_4](images/tip39_4.png)  
@@ -40,4 +40,4 @@ In fact, `<C-w><C-w>` === `<C-w>w`, you can press the `<Ctrl>` key and hold it w
 **Resizing and Rearranging Windows**  
 ![tip39_5](images/tip39_5.png)  
       
-#[Tip38](tip38.md) [Tip40](tip40.md)
+# [Tip38](tip38.md) [Tip40](tip40.md)

--- a/tip4.md
+++ b/tip4.md
@@ -1,4 +1,4 @@
-# Tip4: Act, Repeat, Reverse  
-  
-![tip4](images/tip4.png)  
+# Tip4: Act, Repeat, Reverse
+
+![tip4](images/tip4.png)
 # [Tip3](tip3.md)  [Tip5](tip5.md)

--- a/tip4.md
+++ b/tip4.md
@@ -1,4 +1,4 @@
-#Tip4: Act, Repeat, Reverse  
+# Tip4: Act, Repeat, Reverse  
   
 ![tip4](images/tip4.png)  
-#[Tip3](tip3.md)  [Tip5](tip5.md)
+# [Tip3](tip3.md)  [Tip5](tip5.md)

--- a/tip40.md
+++ b/tip40.md
@@ -1,4 +1,4 @@
-#Tip40: Organize Your Window Layouts with Tab Pages  
+# Tip40: Organize Your Window Layouts with Tab Pages  
   
 ![tip40_1](images/tip40_1.png)  
   
@@ -7,7 +7,7 @@ In Vim, a **tab page** is a container that can hold a collection of windows.
 `:edit`: vim doesn't automatically create a new tab.  
 Instead, it creates a new **buffer** and loads it into the current window.  
   
-##:lcd {path}  
+## :lcd {path}  
 >set the working directory locally for the **current window**, not to the current tab page.  
 >a tab page can contains one or more windows.  
   
@@ -19,9 +19,9 @@ Tabs are numbered starting from 1. We can **goto tab{N}**.
 ![tip40_3](images/tip40_3.png)  
   
 **Rearranging Tabs**  
-##:tabmove [N]  
+## :tabmove [N]  
 >rearranging tab pages.  
 > [N] is 0, the current tab page is moved to the beginning.  
 > omit [N], the current tab page is moved to the end.  
   
-#[Tip39](tip39.md) [Tip41](tip41.md)
+# [Tip39](tip39.md) [Tip41](tip41.md)

--- a/tip40.md
+++ b/tip40.md
@@ -1,27 +1,27 @@
-# Tip40: Organize Your Window Layouts with Tab Pages  
-  
-![tip40_1](images/tip40_1.png)  
-  
-In Vim, a **tab page** is a container that can hold a collection of windows.  
-  
-`:edit`: vim doesn't automatically create a new tab.  
-Instead, it creates a new **buffer** and loads it into the current window.  
-  
-## :lcd {path}  
->set the working directory locally for the **current window**, not to the current tab page.  
->a tab page can contains one or more windows.  
-  
-**Opening and Closing Tabs**  
-![tip40_2](images/tip40_2.png)  
-      
-**Switching Between Tabs**  
-Tabs are numbered starting from 1. We can **goto tab{N}**.  
-![tip40_3](images/tip40_3.png)  
-  
-**Rearranging Tabs**  
-## :tabmove [N]  
->rearranging tab pages.  
-> [N] is 0, the current tab page is moved to the beginning.  
-> omit [N], the current tab page is moved to the end.  
-  
+# Tip40: Organize Your Window Layouts with Tab Pages
+
+![tip40_1](images/tip40_1.png)
+
+In Vim, a **tab page** is a container that can hold a collection of windows.
+
+`:edit`: vim doesn't automatically create a new tab.
+Instead, it creates a new **buffer** and loads it into the current window.
+
+## :lcd {path}
+>set the working directory locally for the **current window**, not to the current tab page.
+>a tab page can contains one or more windows.
+
+**Opening and Closing Tabs**
+![tip40_2](images/tip40_2.png)
+
+**Switching Between Tabs**
+Tabs are numbered starting from 1. We can **goto tab{N}**.
+![tip40_3](images/tip40_3.png)
+
+**Rearranging Tabs**
+## :tabmove [N]
+>rearranging tab pages.
+> [N] is 0, the current tab page is moved to the beginning.
+> omit [N], the current tab page is moved to the end.
+
 # [Tip39](tip39.md) [Tip41](tip41.md)

--- a/tip41.md
+++ b/tip41.md
@@ -1,26 +1,26 @@
-#Tip41: Open a File by Its Filepath Using `:edit`  
+# Tip41: Open a File by Its Filepath Using `:edit`  
   
-##:edit  
+## :edit  
 >open files by an absolute or a relative filepath.  
   
 **Open a File Relative to the Current Working Directory**  
   
-##:pwd  
+## :pwd  
 >print working directory.  
   
-##:edit relative/path/file.ext  
+## :edit relative/path/file.ext  
 >tab: autocomplete filepath.  
   
 **Open a File Relative to the Active File Directory**  
   
-##:edit %&lt;Tab&gt;  
+## :edit %&lt;Tab&gt;  
 >%: shorthand for the filepath of the active buffer.  
 >Tab: expand the filepath.  
   
-##:edit %:h&lt;Tab&gt;  
+## :edit %:h&lt;Tab&gt;  
 >:h : remove the filename while preserving the rest of the path.  
   
 Note: a mapping:  
 ![tip41](images/tip41.png)  
   
-#[Tip40](tip40.md) [Tip42](tip42.md)
+# [Tip40](tip40.md) [Tip42](tip42.md)

--- a/tip41.md
+++ b/tip41.md
@@ -1,26 +1,26 @@
-# Tip41: Open a File by Its Filepath Using `:edit`  
-  
-## :edit  
->open files by an absolute or a relative filepath.  
-  
-**Open a File Relative to the Current Working Directory**  
-  
-## :pwd  
->print working directory.  
-  
-## :edit relative/path/file.ext  
->tab: autocomplete filepath.  
-  
-**Open a File Relative to the Active File Directory**  
-  
-## :edit %&lt;Tab&gt;  
->%: shorthand for the filepath of the active buffer.  
->Tab: expand the filepath.  
-  
-## :edit %:h&lt;Tab&gt;  
->:h : remove the filename while preserving the rest of the path.  
-  
-Note: a mapping:  
-![tip41](images/tip41.png)  
-  
+# Tip41: Open a File by Its Filepath Using `:edit`
+
+## :edit
+>open files by an absolute or a relative filepath.
+
+**Open a File Relative to the Current Working Directory**
+
+## :pwd
+>print working directory.
+
+## :edit relative/path/file.ext
+>tab: autocomplete filepath.
+
+**Open a File Relative to the Active File Directory**
+
+## :edit %&lt;Tab&gt;
+>%: shorthand for the filepath of the active buffer.
+>Tab: expand the filepath.
+
+## :edit %:h&lt;Tab&gt;
+>:h : remove the filename while preserving the rest of the path.
+
+Note: a mapping:
+![tip41](images/tip41.png)
+
 # [Tip40](tip40.md) [Tip42](tip42.md)

--- a/tip42.md
+++ b/tip42.md
@@ -1,18 +1,18 @@
-# Tip42: Open a File by Its Filename Using `:find`  
-  
-## :find  
->open a file by its name without having to provide a fully qualified path.  
-  
-**Configure the 'path'**  
->'path' option allows us to specify a set of directories inside of which Vim will search when `:find` command is invoked.  
-  
-## :set path+=app/**  
->`**`: matches all subdirectories beneath the app/ directory.  
-  
-**Use `:find` to Look up Files by Name**  
-  
-## :find Main.js&lt;Tab&gt;  
->after first Tab, vim expands the entire path of the first full match.  
->after second Tab, vim expands the next matching full filepath.  
-  
+# Tip42: Open a File by Its Filename Using `:find`
+
+## :find
+>open a file by its name without having to provide a fully qualified path.
+
+**Configure the 'path'**
+>'path' option allows us to specify a set of directories inside of which Vim will search when `:find` command is invoked.
+
+## :set path+=app/**
+>`**`: matches all subdirectories beneath the app/ directory.
+
+**Use `:find` to Look up Files by Name**
+
+## :find Main.js&lt;Tab&gt;
+>after first Tab, vim expands the entire path of the first full match.
+>after second Tab, vim expands the next matching full filepath.
+
 # [Tip41](tip41.md) [Tip43](tip43.md)

--- a/tip42.md
+++ b/tip42.md
@@ -1,18 +1,18 @@
-#Tip42: Open a File by Its Filename Using `:find`  
+# Tip42: Open a File by Its Filename Using `:find`  
   
-##:find  
+## :find  
 >open a file by its name without having to provide a fully qualified path.  
   
 **Configure the 'path'**  
 >'path' option allows us to specify a set of directories inside of which Vim will search when `:find` command is invoked.  
   
-##:set path+=app/**  
+## :set path+=app/**  
 >`**`: matches all subdirectories beneath the app/ directory.  
   
 **Use `:find` to Look up Files by Name**  
   
-##:find Main.js&lt;Tab&gt;  
+## :find Main.js&lt;Tab&gt;  
 >after first Tab, vim expands the entire path of the first full match.  
 >after second Tab, vim expands the next matching full filepath.  
   
-#[Tip41](tip41.md) [Tip43](tip43.md)
+# [Tip41](tip41.md) [Tip43](tip43.md)

--- a/tip43.md
+++ b/tip43.md
@@ -1,26 +1,26 @@
-# Tip43: Explore the File System with netrw  
-  
-## Enable netrw plugin  
->set nocompatible  
->filetype plugin on  
-  
-**Meet netrw ---Vim's Native File Explorer**  
-  
-## vim directoryname  
->It's a regular Vim buffer, represents the contents of a directory.  
-  
-if the cursor is positioned on a filename, the file is loaded into a buffer in the current window, replacing the file explorer.  
-  
-## -  
-## .. &lt;CR&gt;  
->goto parent directory.  
-  
-## :edit {directory path}  
->open the file explorer  
-  
-## .  
->stands for the current working directory.  
-  
-![tip43](images/tip43.png)  
-  
+# Tip43: Explore the File System with netrw
+
+## Enable netrw plugin
+>set nocompatible
+>filetype plugin on
+
+**Meet netrw ---Vim's Native File Explorer**
+
+## vim directoryname
+>It's a regular Vim buffer, represents the contents of a directory.
+
+if the cursor is positioned on a filename, the file is loaded into a buffer in the current window, replacing the file explorer.
+
+## -
+## .. &lt;CR&gt;
+>goto parent directory.
+
+## :edit {directory path}
+>open the file explorer
+
+## .
+>stands for the current working directory.
+
+![tip43](images/tip43.png)
+
 # [Tip42](tip42.md) [Tip44](tip44.md)

--- a/tip43.md
+++ b/tip43.md
@@ -1,26 +1,26 @@
-#Tip43: Explore the File System with netrw  
+# Tip43: Explore the File System with netrw  
   
-##Enable netrw plugin  
+## Enable netrw plugin  
 >set nocompatible  
 >filetype plugin on  
   
 **Meet netrw ---Vim's Native File Explorer**  
   
-##vim directoryname  
+## vim directoryname  
 >It's a regular Vim buffer, represents the contents of a directory.  
   
 if the cursor is positioned on a filename, the file is loaded into a buffer in the current window, replacing the file explorer.  
   
-##-  
-##.. &lt;CR&gt;  
+## -  
+## .. &lt;CR&gt;  
 >goto parent directory.  
   
-##:edit {directory path}  
+## :edit {directory path}  
 >open the file explorer  
   
-##.  
+## .  
 >stands for the current working directory.  
   
 ![tip43](images/tip43.png)  
   
-#[Tip42](tip42.md) [Tip44](tip44.md)
+# [Tip42](tip42.md) [Tip44](tip44.md)

--- a/tip44.md
+++ b/tip44.md
@@ -1,13 +1,13 @@
-#Tip44: Save Files to Nonexistent Directories  
+# Tip44: Save Files to Nonexistent Directories  
   
-##&lt;C-g&gt;  
+## &lt;C-g&gt;  
 >echo the name and status of the current file.  
   
 When we run the :write command, Vim will attempt to write the contents of that buffer to a new file using the filepath that was specified when the buffer was created.  
   
-##:!mkdir -p %:h  
+## :!mkdir -p %:h  
 >-p: tell `mkdir` to create intermediate directories.  
   
-##:write  
+## :write  
   
-#[Tip43](tip43.md) [Tip45](tip45.md)
+# [Tip43](tip43.md) [Tip45](tip45.md)

--- a/tip44.md
+++ b/tip44.md
@@ -1,13 +1,13 @@
-# Tip44: Save Files to Nonexistent Directories  
-  
-## &lt;C-g&gt;  
->echo the name and status of the current file.  
-  
-When we run the :write command, Vim will attempt to write the contents of that buffer to a new file using the filepath that was specified when the buffer was created.  
-  
-## :!mkdir -p %:h  
->-p: tell `mkdir` to create intermediate directories.  
-  
-## :write  
-  
+# Tip44: Save Files to Nonexistent Directories
+
+## &lt;C-g&gt;
+>echo the name and status of the current file.
+
+When we run the :write command, Vim will attempt to write the contents of that buffer to a new file using the filepath that was specified when the buffer was created.
+
+## :!mkdir -p %:h
+>-p: tell `mkdir` to create intermediate directories.
+
+## :write
+
 # [Tip43](tip43.md) [Tip45](tip45.md)

--- a/tip45.md
+++ b/tip45.md
@@ -1,12 +1,12 @@
-#Tip45: Save a File as the Super User  
+# Tip45: Save a File as the Super User  
   
 `vim /etc/hosts`: open the hosts file.  
 `<C-g>`: echo the status of the file, in this case : [RO]  
 `Go`: add a blank line at the end of the file. Vim echoes a message that reads 'W10: Warning: Changing a readonly file.', after showing that message, Vim proceeds by making the change anyway.  
 Note: Vim won't prevent us from making changes to a readonly buffer, but it will prevent us from saving the changes to disk.  
   
-##:w !sudo tee % &gt; /dev/null  
+## :w !sudo tee % &gt; /dev/null  
 >`%`: expands to represent the path of the current buffer, in this case: /etc/hosts  
 >`tee /etc/hosts > /dev/null`: receives the contents of the buffer as standard input, using it to overwrite the contents of the /etc/hosts file.  
   
-#[Tip44](tip44.md) [Tip46](tip46.md)
+# [Tip44](tip44.md) [Tip46](tip46.md)

--- a/tip45.md
+++ b/tip45.md
@@ -1,12 +1,12 @@
-# Tip45: Save a File as the Super User  
-  
-`vim /etc/hosts`: open the hosts file.  
-`<C-g>`: echo the status of the file, in this case : [RO]  
-`Go`: add a blank line at the end of the file. Vim echoes a message that reads 'W10: Warning: Changing a readonly file.', after showing that message, Vim proceeds by making the change anyway.  
-Note: Vim won't prevent us from making changes to a readonly buffer, but it will prevent us from saving the changes to disk.  
-  
-## :w !sudo tee % &gt; /dev/null  
->`%`: expands to represent the path of the current buffer, in this case: /etc/hosts  
->`tee /etc/hosts > /dev/null`: receives the contents of the buffer as standard input, using it to overwrite the contents of the /etc/hosts file.  
-  
+# Tip45: Save a File as the Super User
+
+`vim /etc/hosts`: open the hosts file.
+`<C-g>`: echo the status of the file, in this case : [RO]
+`Go`: add a blank line at the end of the file. Vim echoes a message that reads 'W10: Warning: Changing a readonly file.', after showing that message, Vim proceeds by making the change anyway.
+Note: Vim won't prevent us from making changes to a readonly buffer, but it will prevent us from saving the changes to disk.
+
+## :w !sudo tee % &gt; /dev/null
+>`%`: expands to represent the path of the current buffer, in this case: /etc/hosts
+>`tee /etc/hosts > /dev/null`: receives the contents of the buffer as standard input, using it to overwrite the contents of the /etc/hosts file.
+
 # [Tip44](tip44.md) [Tip46](tip46.md)

--- a/tip46.md
+++ b/tip46.md
@@ -1,8 +1,8 @@
-#Tip46: Keep Your Fingers on the Home Row  
+# Tip46: Keep Your Fingers on the Home Row  
   
 **h**: one column left  
 **l**: one column right  
 **j**: one line down  
 **k**: one line up  
   
-#[Tip45](tip45.md) [Tip47](tip47.md)
+# [Tip45](tip45.md) [Tip47](tip47.md)

--- a/tip46.md
+++ b/tip46.md
@@ -1,8 +1,8 @@
-# Tip46: Keep Your Fingers on the Home Row  
-  
-**h**: one column left  
-**l**: one column right  
-**j**: one line down  
-**k**: one line up  
-  
+# Tip46: Keep Your Fingers on the Home Row
+
+**h**: one column left
+**l**: one column right
+**j**: one line down
+**k**: one line up
+
 # [Tip45](tip45.md) [Tip47](tip47.md)

--- a/tip47.md
+++ b/tip47.md
@@ -1,4 +1,4 @@
-#Tip47: Distinguish Between Real Line and Display Lines  
+# Tip47: Distinguish Between Real Line and Display Lines  
   
 A single line in the file may be represented by multiple lines on the display.  
   
@@ -10,4 +10,4 @@ A single line in the file may be represented by multiple lines on the display.
 `j, k, 0, $`: interact with real lines.  
 `g`: tell vim to act on display lines instead.  
   
-#[Tip46](tip46.md) [Tip48](tip48.md)
+# [Tip46](tip46.md) [Tip48](tip48.md)

--- a/tip47.md
+++ b/tip47.md
@@ -1,13 +1,13 @@
-# Tip47: Distinguish Between Real Line and Display Lines  
-  
-A single line in the file may be represented by multiple lines on the display.  
-  
-**Real Lines**: begin with a number, may span one or more display lines.  
-**Display Lines**: begin without a line number, wrapped to fit inside the window.  
-  
-![tip47](images/tip47.png)  
-      
-`j, k, 0, $`: interact with real lines.  
-`g`: tell vim to act on display lines instead.  
-  
+# Tip47: Distinguish Between Real Line and Display Lines
+
+A single line in the file may be represented by multiple lines on the display.
+
+**Real Lines**: begin with a number, may span one or more display lines.
+**Display Lines**: begin without a line number, wrapped to fit inside the window.
+
+![tip47](images/tip47.png)
+
+`j, k, 0, $`: interact with real lines.
+`g`: tell vim to act on display lines instead.
+
 # [Tip46](tip46.md) [Tip48](tip48.md)

--- a/tip48.md
+++ b/tip48.md
@@ -1,31 +1,31 @@
-# Tip48: Move Word-Wise  
-  
-## word  
->consists of a sequence of letters, digits, and underscores, or as a sequence of other nonblank characters separated with whitespace.  
-  
-## WORD  
->consists of a sequence of nonblank characters separated with whitespace.  
-  
-e.g. we're going too slow  
->this contains **five** WORDS and ten words.  
->because periods and apostrophes count as words.  
-  
-  
-**words**  
-![tip48_1](images/tip48_1.png)  
-  
-![tip48_2](images/tip48_2.png)  
-  
-## ea  
->append at the end of the current word.  
-  
-## gea  
->append at the end of the previous word.  
-  
-  
-**WORDS**  
-![tip48_3](images/tip48_3.png)  
-  
-![tip48_4](images/tip48_4.png)  
-  
+# Tip48: Move Word-Wise
+
+## word
+>consists of a sequence of letters, digits, and underscores, or as a sequence of other nonblank characters separated with whitespace.
+
+## WORD
+>consists of a sequence of nonblank characters separated with whitespace.
+
+e.g. we're going too slow
+>this contains **five** WORDS and ten words.
+>because periods and apostrophes count as words.
+
+
+**words**
+![tip48_1](images/tip48_1.png)
+
+![tip48_2](images/tip48_2.png)
+
+## ea
+>append at the end of the current word.
+
+## gea
+>append at the end of the previous word.
+
+
+**WORDS**
+![tip48_3](images/tip48_3.png)
+
+![tip48_4](images/tip48_4.png)
+
 # [Tip47](tip47.md) [Tip49](tip49.md)

--- a/tip48.md
+++ b/tip48.md
@@ -1,9 +1,9 @@
-#Tip48: Move Word-Wise  
+# Tip48: Move Word-Wise  
   
-##word  
+## word  
 >consists of a sequence of letters, digits, and underscores, or as a sequence of other nonblank characters separated with whitespace.  
   
-##WORD  
+## WORD  
 >consists of a sequence of nonblank characters separated with whitespace.  
   
 e.g. we're going too slow  
@@ -16,10 +16,10 @@ e.g. we're going too slow
   
 ![tip48_2](images/tip48_2.png)  
   
-##ea  
+## ea  
 >append at the end of the current word.  
   
-##gea  
+## gea  
 >append at the end of the previous word.  
   
   
@@ -28,4 +28,4 @@ e.g. we're going too slow
   
 ![tip48_4](images/tip48_4.png)  
   
-#[Tip47](tip47.md) [Tip49](tip49.md)
+# [Tip47](tip47.md) [Tip49](tip49.md)

--- a/tip49.md
+++ b/tip49.md
@@ -1,29 +1,29 @@
-# Tip49: Find by Character  
-  
-## f{char}  
->search for the specified character, starting with the cursor position and continuing to the end of the current line.  
-  
-![tip49_1](images/tip49_1.png)  
-  
-![tip49_2](images/tip49_2.png)  
-  
-## ;  
->repeat f command   
-  
-## ,  
->repeat the last f command search but in the opposite direction.  
-  
-![tip49_3](images/tip49_3.png)  
-  
-  
-**Character Searches Can Include or Exclude the Target**  
-  
-![tip49_4](images/tip49_4.png)  
-  
->`t{char}`, `T{char}`: searching **till** the specified character. The cursor stops one character **before**{char}.  
->`f{char}`, `F{char}`: position the cursor on top of the specified character.  
-  
-![tip49_5](images/tip49_5.png)  
-after `f,`, we want to delete all of the text until the end of the sentence.  
-  
+# Tip49: Find by Character
+
+## f{char}
+>search for the specified character, starting with the cursor position and continuing to the end of the current line.
+
+![tip49_1](images/tip49_1.png)
+
+![tip49_2](images/tip49_2.png)
+
+## ;
+>repeat f command
+
+## ,
+>repeat the last f command search but in the opposite direction.
+
+![tip49_3](images/tip49_3.png)
+
+
+**Character Searches Can Include or Exclude the Target**
+
+![tip49_4](images/tip49_4.png)
+
+>`t{char}`, `T{char}`: searching **till** the specified character. The cursor stops one character **before**{char}.
+>`f{char}`, `F{char}`: position the cursor on top of the specified character.
+
+![tip49_5](images/tip49_5.png)
+after `f,`, we want to delete all of the text until the end of the sentence.
+
 # [Tip48](tip48.md) [Tip50](tip50.md)

--- a/tip49.md
+++ b/tip49.md
@@ -1,16 +1,16 @@
-#Tip49: Find by Character  
+# Tip49: Find by Character  
   
-##f{char}  
+## f{char}  
 >search for the specified character, starting with the cursor position and continuing to the end of the current line.  
   
 ![tip49_1](images/tip49_1.png)  
   
 ![tip49_2](images/tip49_2.png)  
   
-##;  
+## ;  
 >repeat f command   
   
-##,  
+## ,  
 >repeat the last f command search but in the opposite direction.  
   
 ![tip49_3](images/tip49_3.png)  
@@ -26,4 +26,4 @@
 ![tip49_5](images/tip49_5.png)  
 after `f,`, we want to delete all of the text until the end of the sentence.  
   
-#[Tip48](tip48.md) [Tip50](tip50.md)
+# [Tip48](tip48.md) [Tip50](tip50.md)

--- a/tip5.md
+++ b/tip5.md
@@ -1,22 +1,22 @@
-# Tip5: Find and Replace by Hand  
-  
-## Search 'target' and replace all the 'target'  
->:%s/target/replacemnet/g  
-  
-## But one by one?  
-  
-## /target  
->search document for next match.  
-  
+# Tip5: Find and Replace by Hand
+
+## Search 'target' and replace all the 'target'
+>:%s/target/replacemnet/g
+
+## But one by one?
+
+## /target
+>search document for next match.
+
 ## *
->execute a search for the word under the cursor at that moment.  
-  
-## *nn  
->cycle through all matches, taking us back to where we started.  
-  
-## cw  
->delete to the end of the word and drop us into Insert mode.  
-  
-# Example  
-![tip5](images/tip5.png)  
+>execute a search for the word under the cursor at that moment.
+
+## *nn
+>cycle through all matches, taking us back to where we started.
+
+## cw
+>delete to the end of the word and drop us into Insert mode.
+
+# Example
+![tip5](images/tip5.png)
 # [Tip4](tip4.md) [Tip6](tip6.md)

--- a/tip5.md
+++ b/tip5.md
@@ -1,22 +1,22 @@
-#Tip5: Find and Replace by Hand  
+# Tip5: Find and Replace by Hand  
   
-##Search 'target' and replace all the 'target'  
+## Search 'target' and replace all the 'target'  
 >:%s/target/replacemnet/g  
   
-##But one by one?  
+## But one by one?  
   
-##/target  
+## /target  
 >search document for next match.  
   
-##*
+## *
 >execute a search for the word under the cursor at that moment.  
   
-##*nn  
+## *nn  
 >cycle through all matches, taking us back to where we started.  
   
-##cw  
+## cw  
 >delete to the end of the word and drop us into Insert mode.  
   
-#Example  
+# Example  
 ![tip5](images/tip5.png)  
-#[Tip4](tip4.md) [Tip6](tip6.md)
+# [Tip4](tip4.md) [Tip6](tip6.md)

--- a/tip50.md
+++ b/tip50.md
@@ -1,16 +1,16 @@
-#Tip50: Search to Navigate  
+# Tip50: Search to Navigate  
   
 `f{char}`, `t{char}` can only search for **a single character** at a time, and they can only operate within the **current line**.  
   
-##/{char}  
+## /{char}  
 > search mode  
   
 ![tip50_1](images/tip50_1.png)  
   
-##n  
+## n  
 >repeat the previous search  
   
-##N  
+## N  
 >backup  
   
 **Operate with a Search Motion**  
@@ -21,5 +21,5 @@ search command can use in Normal mode, Visual mode, Operator-Pending mode
   
 ![tip50_3](images/tip50_3.png)  
   
-#[Tip49](tip49.md) [Tip51](tip51.md)
+# [Tip49](tip49.md) [Tip51](tip51.md)
 

--- a/tip50.md
+++ b/tip50.md
@@ -1,25 +1,25 @@
-# Tip50: Search to Navigate  
-  
-`f{char}`, `t{char}` can only search for **a single character** at a time, and they can only operate within the **current line**.  
-  
-## /{char}  
-> search mode  
-  
-![tip50_1](images/tip50_1.png)  
-  
-## n  
->repeat the previous search  
-  
-## N  
->backup  
-  
-**Operate with a Search Motion**  
-search command can use in Normal mode, Visual mode, Operator-Pending mode  
-![tip50_2](images/tip50_2.png)  
->`v` switch to Visual mode.  
->extend the selection by searching for the short 'ge' string.  
-  
-![tip50_3](images/tip50_3.png)  
-  
+# Tip50: Search to Navigate
+
+`f{char}`, `t{char}` can only search for **a single character** at a time, and they can only operate within the **current line**.
+
+## /{char}
+> search mode
+
+![tip50_1](images/tip50_1.png)
+
+## n
+>repeat the previous search
+
+## N
+>backup
+
+**Operate with a Search Motion**
+search command can use in Normal mode, Visual mode, Operator-Pending mode
+![tip50_2](images/tip50_2.png)
+>`v` switch to Visual mode.
+>extend the selection by searching for the short 'ge' string.
+
+![tip50_3](images/tip50_3.png)
+
 # [Tip49](tip49.md) [Tip51](tip51.md)
 

--- a/tip51.md
+++ b/tip51.md
@@ -1,33 +1,33 @@
-# Tip51: Trace Your Selection with Precision Text Objects  
-  
-## Text Objects  
->define regions of text by structure. It allow us to operate on the regions of text that they delimit.  
-  
-![tip51_1](images/tip51_1.png)  
-  
-## vi}  
->Vim initiates Visual mode and then selects all of the characters contained by the {} braces.  
->Where the cursor is positioned to begin with doesn't matter so long as it's located somewhere inside a block of curly braces when the `i}` text object is invoked.  
-  
-## a"  
->selects a range of characters delimited by double quotes.  
-  
->`i`: select **inside** the delimiters.(inside)  
->`a`: select **everything** including the delimiters.(around/all)  
-  
-![tip51_2](images/tip51_2.png)  
-  
-Note:  
->Text objects are not motions themselves:  
->we can not use them to navigate around the document.  
->we can use them in Visual mode and in Operator-Pending mode.  
-  
-**Remember this: whenever you see {motion} as part of the syntax for a command, you can also use a text object.** Common examples include `d{motion}`, `c{motion}`, `y{motion}`.  
-  
-![tip51_3](images/tip51_3.png)  
->`ci"`: change inside the double quotes.  
->`cit`: change inside the tag.  
->`yit`: yank the text from inside the tag.  
->`dit`: delete the text from inside the tag.  
-  
+# Tip51: Trace Your Selection with Precision Text Objects
+
+## Text Objects
+>define regions of text by structure. It allow us to operate on the regions of text that they delimit.
+
+![tip51_1](images/tip51_1.png)
+
+## vi}
+>Vim initiates Visual mode and then selects all of the characters contained by the {} braces.
+>Where the cursor is positioned to begin with doesn't matter so long as it's located somewhere inside a block of curly braces when the `i}` text object is invoked.
+
+## a"
+>selects a range of characters delimited by double quotes.
+
+>`i`: select **inside** the delimiters.(inside)
+>`a`: select **everything** including the delimiters.(around/all)
+
+![tip51_2](images/tip51_2.png)
+
+Note:
+>Text objects are not motions themselves:
+>we can not use them to navigate around the document.
+>we can use them in Visual mode and in Operator-Pending mode.
+
+**Remember this: whenever you see {motion} as part of the syntax for a command, you can also use a text object.** Common examples include `d{motion}`, `c{motion}`, `y{motion}`.
+
+![tip51_3](images/tip51_3.png)
+>`ci"`: change inside the double quotes.
+>`cit`: change inside the tag.
+>`yit`: yank the text from inside the tag.
+>`dit`: delete the text from inside the tag.
+
 # [Tip50](tip50.md) [Tip52](tip52.md)

--- a/tip51.md
+++ b/tip51.md
@@ -1,15 +1,15 @@
-#Tip51: Trace Your Selection with Precision Text Objects  
+# Tip51: Trace Your Selection with Precision Text Objects  
   
-##Text Objects  
+## Text Objects  
 >define regions of text by structure. It allow us to operate on the regions of text that they delimit.  
   
 ![tip51_1](images/tip51_1.png)  
   
-##vi}  
+## vi}  
 >Vim initiates Visual mode and then selects all of the characters contained by the {} braces.  
 >Where the cursor is positioned to begin with doesn't matter so long as it's located somewhere inside a block of curly braces when the `i}` text object is invoked.  
   
-##a"  
+## a"  
 >selects a range of characters delimited by double quotes.  
   
 >`i`: select **inside** the delimiters.(inside)  
@@ -30,4 +30,4 @@ Note:
 >`yit`: yank the text from inside the tag.  
 >`dit`: delete the text from inside the tag.  
   
-#[Tip50](tip50.md) [Tip52](tip52.md)
+# [Tip50](tip50.md) [Tip52](tip52.md)

--- a/tip52.md
+++ b/tip52.md
@@ -1,4 +1,4 @@
-#Tip52: Delete Around, or Change Inside  
+# Tip52: Delete Around, or Change Inside  
   
 **delimited text objects**  
 >they begin and end with matching symbols. that inside the object.  
@@ -8,10 +8,10 @@
   
 ![tip52_1](images/tip52_1.png)  
   
-##iw  
+## iw  
 >interacts with everything from the first to the last character of the current word.  
   
-##aw  
+## aw  
 >does the same with `iw`, but it extends the range to include a whitespace character after or before the word, if one is present.  
   
 ![tip52_2](images/tip52_2.png)  
@@ -21,4 +21,4 @@
 >`d{motion}`: tends to work with `aw`, `as`, `ap`  
 >`c{motion}`: tends to work with `iw`, `is`, `ip`  
   
-#[Tip51](tip51.md) [Tip53](tip53.md)
+# [Tip51](tip51.md) [Tip53](tip53.md)

--- a/tip52.md
+++ b/tip52.md
@@ -1,24 +1,24 @@
-# Tip52: Delete Around, or Change Inside  
-  
-**delimited text objects**  
->they begin and end with matching symbols. that inside the object.  
-  
-**bounded text objects**  
->words, sentences, and paragraphs are defined by boundaries. that around the object.  
-  
-![tip52_1](images/tip52_1.png)  
-  
-## iw  
->interacts with everything from the first to the last character of the current word.  
-  
-## aw  
->does the same with `iw`, but it extends the range to include a whitespace character after or before the word, if one is present.  
-  
-![tip52_2](images/tip52_2.png)  
-  
-![tip52_3](images/tip52_3.png)  
-  
->`d{motion}`: tends to work with `aw`, `as`, `ap`  
->`c{motion}`: tends to work with `iw`, `is`, `ip`  
-  
+# Tip52: Delete Around, or Change Inside
+
+**delimited text objects**
+>they begin and end with matching symbols. that inside the object.
+
+**bounded text objects**
+>words, sentences, and paragraphs are defined by boundaries. that around the object.
+
+![tip52_1](images/tip52_1.png)
+
+## iw
+>interacts with everything from the first to the last character of the current word.
+
+## aw
+>does the same with `iw`, but it extends the range to include a whitespace character after or before the word, if one is present.
+
+![tip52_2](images/tip52_2.png)
+
+![tip52_3](images/tip52_3.png)
+
+>`d{motion}`: tends to work with `aw`, `as`, `ap`
+>`c{motion}`: tends to work with `iw`, `is`, `ip`
+
 # [Tip51](tip51.md) [Tip53](tip53.md)

--- a/tip53.md
+++ b/tip53.md
@@ -1,21 +1,21 @@
-# Tip53: Mark Your Place and Snap Back to It  
-  
-**Set the mark**  
-## m{a-zA-Z}  
->marks the current cursor location with the designated letter.  
->lowercase marks are local to each individual buffer.  
->uppercase marks are globally accessible.  
-  
-**Two Normal mode commands**  
-## '{mark}  
->moves to the line where a mark was set, positioning the cursor on the first non-whitespace character.  
-  
-## `{mark}  
->moves the cursor to the exact position where a mark was set, restoring the line and the column at once.  
-  
-Note: `mm`, ``m`: make a handy pair. They set the mark m and jump to it.  
-  
-**Vim's Automatic Marks**  
-![tip53](images/tip53.png)  
-      
+# Tip53: Mark Your Place and Snap Back to It
+
+**Set the mark**
+## m{a-zA-Z}
+>marks the current cursor location with the designated letter.
+>lowercase marks are local to each individual buffer.
+>uppercase marks are globally accessible.
+
+**Two Normal mode commands**
+## '{mark}
+>moves to the line where a mark was set, positioning the cursor on the first non-whitespace character.
+
+## `{mark}
+>moves the cursor to the exact position where a mark was set, restoring the line and the column at once.
+
+Note: `mm`, ``m`: make a handy pair. They set the mark m and jump to it.
+
+**Vim's Automatic Marks**
+![tip53](images/tip53.png)
+
 # [Tip52](tip52.md) [Tip54](tip54.md)

--- a/tip53.md
+++ b/tip53.md
@@ -1,16 +1,16 @@
-#Tip53: Mark Your Place and Snap Back to It  
+# Tip53: Mark Your Place and Snap Back to It  
   
 **Set the mark**  
-##m{a-zA-Z}  
+## m{a-zA-Z}  
 >marks the current cursor location with the designated letter.  
 >lowercase marks are local to each individual buffer.  
 >uppercase marks are globally accessible.  
   
 **Two Normal mode commands**  
-##'{mark}  
+## '{mark}  
 >moves to the line where a mark was set, positioning the cursor on the first non-whitespace character.  
   
-##`{mark}  
+## `{mark}  
 >moves the cursor to the exact position where a mark was set, restoring the line and the column at once.  
   
 Note: `mm`, ``m`: make a handy pair. They set the mark m and jump to it.  
@@ -18,4 +18,4 @@ Note: `mm`, ``m`: make a handy pair. They set the mark m and jump to it.
 **Vim's Automatic Marks**  
 ![tip53](images/tip53.png)  
       
-#[Tip52](tip52.md) [Tip54](tip54.md)
+# [Tip52](tip52.md) [Tip54](tip54.md)

--- a/tip54.md
+++ b/tip54.md
@@ -1,26 +1,26 @@
-# Tip54: Jump Between Matching Parentheses  
-  
-## %  
->lets us jump between opening and closing sets of parentheses  
->it workds with () {} []  
-  
-![tip54_1](images/tip54_1.png)  
-      
-![tip54_2](images/tip54_2.png)  
-  
-**Jump Between Matching Keywords**  
-Must enable **matchit** plugin.  
->set nocompatible  
->filetype plugin on  
->runtime macros/matchit.vim  
-  
-**Surround.vim**  
-![tip54_3](images/tip54_3.png)  
-  
-## S"  
->surround the selection with a pair of double quote marks.  
-  
-## cs}]  
->change surrounding {} braces to [] brackets.  
-  
+# Tip54: Jump Between Matching Parentheses
+
+## %
+>lets us jump between opening and closing sets of parentheses
+>it workds with () {} []
+
+![tip54_1](images/tip54_1.png)
+
+![tip54_2](images/tip54_2.png)
+
+**Jump Between Matching Keywords**
+Must enable **matchit** plugin.
+>set nocompatible
+>filetype plugin on
+>runtime macros/matchit.vim
+
+**Surround.vim**
+![tip54_3](images/tip54_3.png)
+
+## S"
+>surround the selection with a pair of double quote marks.
+
+## cs}]
+>change surrounding {} braces to [] brackets.
+
 # [Tip53](tip53.md) [Tip55](tip55.md)

--- a/tip54.md
+++ b/tip54.md
@@ -1,6 +1,6 @@
-#Tip54: Jump Between Matching Parentheses  
+# Tip54: Jump Between Matching Parentheses  
   
-##%  
+## %  
 >lets us jump between opening and closing sets of parentheses  
 >it workds with () {} []  
   
@@ -17,10 +17,10 @@ Must enable **matchit** plugin.
 **Surround.vim**  
 ![tip54_3](images/tip54_3.png)  
   
-##S"  
+## S"  
 >surround the selection with a pair of double quote marks.  
   
-##cs}]  
+## cs}]  
 >change surrounding {} braces to [] brackets.  
   
-#[Tip53](tip53.md) [Tip55](tip55.md)
+# [Tip53](tip53.md) [Tip55](tip55.md)

--- a/tip55.md
+++ b/tip55.md
@@ -1,15 +1,15 @@
-#Tip55: Traverse the Jump List  
+# Tip55: Traverse the Jump List  
   
 **Vim records our location before and after making a jump and provides a couple of commands for retracing our steps.**  
   
-##&lt;C-o&gt;  
+## &lt;C-o&gt;  
 >back button <--  
   
-##&lt;C-i&gt;  
+## &lt;C-i&gt;  
 >forward button -->  
   
 ![tip55_1](images/tip55_1.png)  
   
 ![tip55_2](images/tip55_2.png)  
   
-#[Tip54](tip54.md) [Tip56](tip56.md)
+# [Tip54](tip54.md) [Tip56](tip56.md)

--- a/tip55.md
+++ b/tip55.md
@@ -1,15 +1,15 @@
-# Tip55: Traverse the Jump List  
-  
-**Vim records our location before and after making a jump and provides a couple of commands for retracing our steps.**  
-  
-## &lt;C-o&gt;  
->back button <--  
-  
-## &lt;C-i&gt;  
->forward button -->  
-  
-![tip55_1](images/tip55_1.png)  
-  
-![tip55_2](images/tip55_2.png)  
-  
+# Tip55: Traverse the Jump List
+
+**Vim records our location before and after making a jump and provides a couple of commands for retracing our steps.**
+
+## &lt;C-o&gt;
+>back button <--
+
+## &lt;C-i&gt;
+>forward button -->
+
+![tip55_1](images/tip55_1.png)
+
+![tip55_2](images/tip55_2.png)
+
 # [Tip54](tip54.md) [Tip56](tip56.md)

--- a/tip56.md
+++ b/tip56.md
@@ -1,20 +1,20 @@
-# Tip56: Traverse the Change List  
-  
-**Vim records the location of our cursor after each change we make to a document.**  
-  
-**change list**  
->Vim maintains a list of the modifications we make to each buffer during the course of an editing session.  
-  
-## :changes  
->shows that Vim records the line and column number for each change.  
->`g;`, `g,`: traverse backward and forward through the change list.  
-  
-**Marks for the Last Change**  
-  
-## `.  
->references the position of the last change.  
-  
-## `^  
->tracks the position of the cursor the last time that Insert mode was stopped.  
-  
+# Tip56: Traverse the Change List
+
+**Vim records the location of our cursor after each change we make to a document.**
+
+**change list**
+>Vim maintains a list of the modifications we make to each buffer during the course of an editing session.
+
+## :changes
+>shows that Vim records the line and column number for each change.
+>`g;`, `g,`: traverse backward and forward through the change list.
+
+**Marks for the Last Change**
+
+## `.
+>references the position of the last change.
+
+## `^
+>tracks the position of the cursor the last time that Insert mode was stopped.
+
 # [Tip55](tip55.md) [Tip57](tip57.md)

--- a/tip56.md
+++ b/tip56.md
@@ -1,20 +1,20 @@
-#Tip56: Traverse the Change List  
+# Tip56: Traverse the Change List  
   
 **Vim records the location of our cursor after each change we make to a document.**  
   
 **change list**  
 >Vim maintains a list of the modifications we make to each buffer during the course of an editing session.  
   
-##:changes  
+## :changes  
 >shows that Vim records the line and column number for each change.  
 >`g;`, `g,`: traverse backward and forward through the change list.  
   
 **Marks for the Last Change**  
   
-##`.  
+## `.  
 >references the position of the last change.  
   
-##`^  
+## `^  
 >tracks the position of the cursor the last time that Insert mode was stopped.  
   
-#[Tip55](tip55.md) [Tip57](tip57.md)
+# [Tip55](tip55.md) [Tip57](tip57.md)

--- a/tip57.md
+++ b/tip57.md
@@ -1,19 +1,19 @@
-# Tip57: Jump to the Filename Under the Cursor  
-  
-**Vim treats filenames in our document as a kind of hyperlink. When configured properly, we can use the `gf` command to go to the filename under the cursor.**  
-  
-## gf  
->go to file  
-  
-## :set suffixesadd+=.ext  
->`suffixesadd` option allows us to specify one or more file extensions, which Vim will attempt to use when looking up a filename with the `gf` command.  
-  
-**Specify the Directories to Look Inside**  
-We can configure 'path' option to reference a comma-separated list of directories. When we use gf command, Vim checks each of the directories listed in 'path' to see if it contains a filename that matches the text under the cursor.  
-  
-![tip57_1](images/tip57_1.png)  
-  
->`.` stands for the directory of the current file.  
->empty string(delimited by two adjacent commas) stands for the working directory.  
-  
+# Tip57: Jump to the Filename Under the Cursor
+
+**Vim treats filenames in our document as a kind of hyperlink. When configured properly, we can use the `gf` command to go to the filename under the cursor.**
+
+## gf
+>go to file
+
+## :set suffixesadd+=.ext
+>`suffixesadd` option allows us to specify one or more file extensions, which Vim will attempt to use when looking up a filename with the `gf` command.
+
+**Specify the Directories to Look Inside**
+We can configure 'path' option to reference a comma-separated list of directories. When we use gf command, Vim checks each of the directories listed in 'path' to see if it contains a filename that matches the text under the cursor.
+
+![tip57_1](images/tip57_1.png)
+
+>`.` stands for the directory of the current file.
+>empty string(delimited by two adjacent commas) stands for the working directory.
+
 # [Tip56](tip56.md) [Tip58](tip58.md)

--- a/tip57.md
+++ b/tip57.md
@@ -1,11 +1,11 @@
-#Tip57: Jump to the Filename Under the Cursor  
+# Tip57: Jump to the Filename Under the Cursor  
   
 **Vim treats filenames in our document as a kind of hyperlink. When configured properly, we can use the `gf` command to go to the filename under the cursor.**  
   
-##gf  
+## gf  
 >go to file  
   
-##:set suffixesadd+=.ext  
+## :set suffixesadd+=.ext  
 >`suffixesadd` option allows us to specify one or more file extensions, which Vim will attempt to use when looking up a filename with the `gf` command.  
   
 **Specify the Directories to Look Inside**  
@@ -16,4 +16,4 @@ We can configure 'path' option to reference a comma-separated list of directorie
 >`.` stands for the directory of the current file.  
 >empty string(delimited by two adjacent commas) stands for the working directory.  
   
-#[Tip56](tip56.md) [Tip58](tip58.md)
+# [Tip56](tip56.md) [Tip58](tip58.md)

--- a/tip58.md
+++ b/tip58.md
@@ -1,4 +1,4 @@
-#Tip58: Snap Between Files Using Global Marks  
+# Tip58: Snap Between Files Using Global Marks  
   
 **A global mark is a kind of bookmark that allows us to jump between files.**  
   
@@ -6,11 +6,11 @@
   
 **By default, global marks are persisted between editing sessions**  
   
-##m{letter}  
+## m{letter}  
 > to set a mark.  
   
 **Set a Global Mark Before Going Code Diving**  
-##:vimgrep /fooBar/  
+## :vimgrep /fooBar/  
 >to find all occurrences of a method called fooBar() in our codebase.  
   
 By default, :vimgrep jumps directly to the first match that it finds, which could mean switching to another file.  
@@ -24,5 +24,5 @@ Try to get into a habit of setting a global mark before using any commands that 
   
 Note: set a blobal mark any time you see something that you might want to snap back to later.  
   
-#[Tip57](tip57.md) [Tip59](tip59.md)
+# [Tip57](tip57.md) [Tip59](tip59.md)
 

--- a/tip58.md
+++ b/tip58.md
@@ -1,28 +1,28 @@
-# Tip58: Snap Between Files Using Global Marks  
-  
-**A global mark is a kind of bookmark that allows us to jump between files.**  
-  
-**after set a mark** we can snap our cursor back to it with the `{letter} command.**  
-  
-**By default, global marks are persisted between editing sessions**  
-  
-## m{letter}  
-> to set a mark.  
-  
-**Set a Global Mark Before Going Code Diving**  
-## :vimgrep /fooBar/  
->to find all occurrences of a method called fooBar() in our codebase.  
-  
-By default, :vimgrep jumps directly to the first match that it finds, which could mean switching to another file.  
-At this point, we can use the `<C-o>` command to get back to where we were prior to running :vimgrep.  
-  
-![tip58](images/tip58.png)  
-  
-Try to get into a habit of setting a global mark before using any commands that :  
->interact with the quickfix list, such as `:grep`, `:vimgrep`, `:make`  
->interact with the buffer and argument lists, such as `:args {arglist}`, `:argdo`  
-  
-Note: set a blobal mark any time you see something that you might want to snap back to later.  
-  
+# Tip58: Snap Between Files Using Global Marks
+
+**A global mark is a kind of bookmark that allows us to jump between files.**
+
+**after set a mark** we can snap our cursor back to it with the `{letter} command.**
+
+**By default, global marks are persisted between editing sessions**
+
+## m{letter}
+> to set a mark.
+
+**Set a Global Mark Before Going Code Diving**
+## :vimgrep /fooBar/
+>to find all occurrences of a method called fooBar() in our codebase.
+
+By default, :vimgrep jumps directly to the first match that it finds, which could mean switching to another file.
+At this point, we can use the `<C-o>` command to get back to where we were prior to running :vimgrep.
+
+![tip58](images/tip58.png)
+
+Try to get into a habit of setting a global mark before using any commands that :
+>interact with the quickfix list, such as `:grep`, `:vimgrep`, `:make`
+>interact with the buffer and argument lists, such as `:args {arglist}`, `:argdo`
+
+Note: set a blobal mark any time you see something that you might want to snap back to later.
+
 # [Tip57](tip57.md) [Tip59](tip59.md)
 

--- a/tip59.md
+++ b/tip59.md
@@ -1,45 +1,45 @@
-#Tip59: Delete, Yank, and Put with Vim's Unnamed Register  
+# Tip59: Delete, Yank, and Put with Vim's Unnamed Register  
   
 Normally when we discuss cut, copy, and paste, we talk about putting text on a clipboard.  
 In Vim's terminology, we don't deal with a clipboard but instead with **register**.  
   
 **Transposing Characters**  
-##x  
+## x  
 >cuts the character under the cursor, placing a copy of it in the **unnamed register**.  
   
-##p  
+## p  
 >pastes the contents of the unnamed register **after** the **cursor position**.  
   
-##xp  
+## xp  
 >Transpose the next two characters.  
   
 ![tip59_1](images/tip59_1.png)  
   
 **Transposing Lines**  
-##dd  
+## dd  
 >cuts the current line, placing it into the unnamed register.  
   
-##p  
+## p  
 >pastes the contents of the unnamed register **after** the **current line**.  
   
-##ddp  
+## ddp  
 >Transpose the order of this line and its successor.  
   
 ![tip59_2](images/tip59_2.png)  
   
 **Duplicating Lines**  
-##yyp  
+## yyp  
 >duplicates current line.  Does a line-wise copy and paste.  
   
 ![tip59_3](images/tip59_3.png)  
   
 **Oops! I Clobbered My Yank**  
-##P  
+## P  
 >paste the contents of our unnamed register **in front of** the **cursor**.  
   
-##diw  
+## diw  
 >in this case, overwrite the contents of the unnamed register.  
   
 ![tip59_4](images/tip59_4.png)  
   
-#[Tip58](tip58.md) [Tip60](tip60.md)
+# [Tip58](tip58.md) [Tip60](tip60.md)

--- a/tip59.md
+++ b/tip59.md
@@ -1,45 +1,45 @@
-# Tip59: Delete, Yank, and Put with Vim's Unnamed Register  
-  
-Normally when we discuss cut, copy, and paste, we talk about putting text on a clipboard.  
-In Vim's terminology, we don't deal with a clipboard but instead with **register**.  
-  
-**Transposing Characters**  
-## x  
->cuts the character under the cursor, placing a copy of it in the **unnamed register**.  
-  
-## p  
->pastes the contents of the unnamed register **after** the **cursor position**.  
-  
-## xp  
->Transpose the next two characters.  
-  
-![tip59_1](images/tip59_1.png)  
-  
-**Transposing Lines**  
-## dd  
->cuts the current line, placing it into the unnamed register.  
-  
-## p  
->pastes the contents of the unnamed register **after** the **current line**.  
-  
-## ddp  
->Transpose the order of this line and its successor.  
-  
-![tip59_2](images/tip59_2.png)  
-  
-**Duplicating Lines**  
-## yyp  
->duplicates current line.  Does a line-wise copy and paste.  
-  
-![tip59_3](images/tip59_3.png)  
-  
-**Oops! I Clobbered My Yank**  
-## P  
->paste the contents of our unnamed register **in front of** the **cursor**.  
-  
-## diw  
->in this case, overwrite the contents of the unnamed register.  
-  
-![tip59_4](images/tip59_4.png)  
-  
+# Tip59: Delete, Yank, and Put with Vim's Unnamed Register
+
+Normally when we discuss cut, copy, and paste, we talk about putting text on a clipboard.
+In Vim's terminology, we don't deal with a clipboard but instead with **register**.
+
+**Transposing Characters**
+## x
+>cuts the character under the cursor, placing a copy of it in the **unnamed register**.
+
+## p
+>pastes the contents of the unnamed register **after** the **cursor position**.
+
+## xp
+>Transpose the next two characters.
+
+![tip59_1](images/tip59_1.png)
+
+**Transposing Lines**
+## dd
+>cuts the current line, placing it into the unnamed register.
+
+## p
+>pastes the contents of the unnamed register **after** the **current line**.
+
+## ddp
+>Transpose the order of this line and its successor.
+
+![tip59_2](images/tip59_2.png)
+
+**Duplicating Lines**
+## yyp
+>duplicates current line.  Does a line-wise copy and paste.
+
+![tip59_3](images/tip59_3.png)
+
+**Oops! I Clobbered My Yank**
+## P
+>paste the contents of our unnamed register **in front of** the **cursor**.
+
+## diw
+>in this case, overwrite the contents of the unnamed register.
+
+![tip59_4](images/tip59_4.png)
+
 # [Tip58](tip58.md) [Tip60](tip60.md)

--- a/tip6.md
+++ b/tip6.md
@@ -1,7 +1,7 @@
-# Tip6: Meet the Dot Formula  
-  
-## The Ideal: One Keystroke to Move, One Keystroke to Execute  
-  
-In all of these examples, using the dot command repeats the last change. But that’s not the only thing they share. A single keystroke is all that’s required to move the cursor to its next target. We’re using one keystroke to move and one keystroke to execute. It can’t really get any better than that, can it? It’s an ideal solution. We’ll see this editing strategy coming up again and again, so for the sake of convenience, we’ll refer to this pattern as the **Dot Formula**.  
-  
+# Tip6: Meet the Dot Formula
+
+## The Ideal: One Keystroke to Move, One Keystroke to Execute
+
+In all of these examples, using the dot command repeats the last change. But that’s not the only thing they share. A single keystroke is all that’s required to move the cursor to its next target. We’re using one keystroke to move and one keystroke to execute. It can’t really get any better than that, can it? It’s an ideal solution. We’ll see this editing strategy coming up again and again, so for the sake of convenience, we’ll refer to this pattern as the **Dot Formula**.
+
 # [Tip5](tip5.md)   [Tip7](tip7.md)

--- a/tip6.md
+++ b/tip6.md
@@ -1,7 +1,7 @@
-#Tip6: Meet the Dot Formula  
+# Tip6: Meet the Dot Formula  
   
-##The Ideal: One Keystroke to Move, One Keystroke to Execute  
+## The Ideal: One Keystroke to Move, One Keystroke to Execute  
   
 In all of these examples, using the dot command repeats the last change. But that’s not the only thing they share. A single keystroke is all that’s required to move the cursor to its next target. We’re using one keystroke to move and one keystroke to execute. It can’t really get any better than that, can it? It’s an ideal solution. We’ll see this editing strategy coming up again and again, so for the sake of convenience, we’ll refer to this pattern as the **Dot Formula**.  
   
-#[Tip5](tip5.md)   [Tip7](tip7.md)
+# [Tip5](tip5.md)   [Tip7](tip7.md)

--- a/tip60.md
+++ b/tip60.md
@@ -1,8 +1,8 @@
-#Tip60: Grok Vim's Registers  
+# Tip60: Grok Vim's Registers  
 Rather than using a single clipboard for all cut, copy and paste operations, Vim provides **multiple registers**. When we use the delete, yank, and put commands, we can specify which register we want to interact with.  
   
 **Addressing a Register**  
-##"{register}  
+## "{register}  
 >specify which register we want to use by prefixing the command with `"{register}`. If we don't specify a register, then Vim will use the **unnamed register**.  
   
 **Vim's Terminology Versus the World**  
@@ -12,29 +12,29 @@ Rather than using a single clipboard for all cut, copy and paste operations, Vim
 >4. Vim's **really deleing text** is `_` special register called the **black hole**, from which nothing returns.  
   
 Normal commands:  
-##"ayiw  
+## "ayiw  
 >yank the current word into register a.  
   
-##"bdd  
+## "bdd  
 >cut the current line into register b.  
   
-##"ap  
+## "ap  
 >paste the word from register a.  
   
-##"bp  
+## "bp  
 >paste the line from register b.  
   
 Ex commands:  
-##:delete c  
+## :delete c  
 >cut the current line into register c.  
   
-##:put c  
+## :put c  
 >paste it below the current line.  
   
 **The Unnamed Register ("")**  
 If we don't specify which register we want to interact with, then Vim will use the **unnamed register**, which is addressed by the " symbol.  
   
-##""p  
+## ""p  
 >to address this register explicitly, use two double quote marks. Which is effectively equivalent to `p`.  
   
 The `x`, `s`, `d{motion}`, `c{motion}`, `y{motion}` commands and their uppercase equivalents all set the contents of the unnamed register. In each case, we can prefix `"{register}` to specify another register, but the unnamed register is the default.  
@@ -46,13 +46,13 @@ The yank register is set **only** when we use the `y{motion}` command, it's not 
   
 ![tip60_1](images/tip60_1.png)  
   
-##diw  
+## diw  
 >overwrites the unnamed register, but it leaves the yank register untouched.  
   
-##"0P  
+## "0P  
 >pastes from the yank register.  
   
-##:reg "0  
+## :reg "0  
 >inspect the contents of the unnamed and yank registers.  
   
 **The Named Registers ("a-"z)**  
@@ -67,7 +67,7 @@ When we address a named register with a:
 **The Black Hole Register("_)**  
 The black hole register is a place from which nothing returns. It's addressed by the **underscore** symbol.  
   
-##"_d{motion}  
+## "_d{motion}  
 >deletes the specified text without saving a copy of it.  
   
 ![tip60_3](images/tip60_3.png)  
@@ -76,10 +76,10 @@ The black hole register is a place from which nothing returns. It's addressed by
 All of the registers that we've discussed so far are internal to Vim.  
 If we want to copy some text from inside of Vim and paste it into an external program, then we have to use one of the system clipboards.  
   
-##"+  
+## "+  
 >Vim's plus register references the system clipboard and is addressed by the + symbol.  
   
-##"+p  &lt;C-r&gt;+  
+## "+p  &lt;C-r&gt;+  
 >cut or copy command to capture text in an external application, you can paste it inside Vim using `"+p` command in Normal mode or `<C-r>+` from the Insert mode.  
   
 ![tip60_4](images/tip60_4.png)  
@@ -99,4 +99,4 @@ Vim provides a handful of registers whose values are set **implicitly**. These a
   
 Technically, the "/ register is not read-only, it can be set explicitly using the `:let` command.  
   
-#[Tip59](tip59.md) [Tip61](tip61.md)
+# [Tip59](tip59.md) [Tip61](tip61.md)

--- a/tip60.md
+++ b/tip60.md
@@ -1,102 +1,102 @@
-# Tip60: Grok Vim's Registers  
-Rather than using a single clipboard for all cut, copy and paste operations, Vim provides **multiple registers**. When we use the delete, yank, and put commands, we can specify which register we want to interact with.  
-  
-**Addressing a Register**  
-## "{register}  
->specify which register we want to use by prefixing the command with `"{register}`. If we don't specify a register, then Vim will use the **unnamed register**.  
-  
-**Vim's Terminology Versus the World**  
->1. Vim's **put** command is effectively identical to the **paste** operation. Both words begin with the letter **p**.  
->2. Vim's **yank** command is equivalent to the **copy** operation. Historically, the `c` command was already assigned to the **change** operation.  
->3. Vim's **delete** command is equivalent to the standard **cut** operation. It copies the specified text into a register and then removes if from the document.  
->4. Vim's **really deleing text** is `_` special register called the **black hole**, from which nothing returns.  
-  
-Normal commands:  
-## "ayiw  
->yank the current word into register a.  
-  
-## "bdd  
->cut the current line into register b.  
-  
-## "ap  
->paste the word from register a.  
-  
-## "bp  
->paste the line from register b.  
-  
-Ex commands:  
-## :delete c  
->cut the current line into register c.  
-  
-## :put c  
->paste it below the current line.  
-  
-**The Unnamed Register ("")**  
-If we don't specify which register we want to interact with, then Vim will use the **unnamed register**, which is addressed by the " symbol.  
-  
-## ""p  
->to address this register explicitly, use two double quote marks. Which is effectively equivalent to `p`.  
-  
-The `x`, `s`, `d{motion}`, `c{motion}`, `y{motion}` commands and their uppercase equivalents all set the contents of the unnamed register. In each case, we can prefix `"{register}` to specify another register, but the unnamed register is the default.  
-  
-**The Yank Register ("0)**  
-When we use the `y{motion}` command, the specified text is copied not only into the **unnamed register** but also into the **yank register**, which is addressed by the 0 symbol.  
-  
-The yank register is set **only** when we use the `y{motion}` command, it's not set by the `x`, `s`, `c{motion}`, `d{motion}`.  
-  
-![tip60_1](images/tip60_1.png)  
-  
-## diw  
->overwrites the unnamed register, but it leaves the yank register untouched.  
-  
-## "0P  
->pastes from the yank register.  
-  
-## :reg "0  
->inspect the contents of the unnamed and yank registers.  
-  
-**The Named Registers ("a-"z)**  
-Vim has one named register for each letter of the alphabet. We can cut("ad{motion}), copy("ay{motion}), paste("ap) up to twenty-six pieces of text.  
-  
-![tip60_2](images/tip60_2.png)  
-  
-When we address a named register with a:  
->lowercase letter, it **overwrites** the specified register.  
->uppercase letter, it **appends** to the specified register.  
-  
-**The Black Hole Register("_)**  
-The black hole register is a place from which nothing returns. It's addressed by the **underscore** symbol.  
-  
-## "_d{motion}  
->deletes the specified text without saving a copy of it.  
-  
-![tip60_3](images/tip60_3.png)  
-  
-**The System Clipboard("+) and Selection("*) Registers**  
-All of the registers that we've discussed so far are internal to Vim.  
-If we want to copy some text from inside of Vim and paste it into an external program, then we have to use one of the system clipboards.  
-  
-## "+  
->Vim's plus register references the system clipboard and is addressed by the + symbol.  
-  
-## "+p  &lt;C-r&gt;+  
->cut or copy command to capture text in an external application, you can paste it inside Vim using `"+p` command in Normal mode or `<C-r>+` from the Insert mode.  
-  
-![tip60_4](images/tip60_4.png)  
-  
-The X11 windowing system has a second kind of clipboard called the primary. This represents the **most recently selected text**.  
-In Windows and Mac OS X, there is no primary clipboard.  
-  
-**The Expression Register("=)**  
-Vim's registers can be thought of simply as **containers** that hold a block of text. The expression register = is and exception.  
-When we fetch the contents of the expression register, Vim drops into **Command-Line** mode, showing an = prompt.  
-We can enter a Vim script expression and press `<CR>` to execute it.  
-  
-**More Registers**  
-Vim provides a handful of registers whose values are set **implicitly**. These are known collectively as the read-only registers.  
-  
-![tip60_5](images/tip60_5.png)  
-  
-Technically, the "/ register is not read-only, it can be set explicitly using the `:let` command.  
-  
+# Tip60: Grok Vim's Registers
+Rather than using a single clipboard for all cut, copy and paste operations, Vim provides **multiple registers**. When we use the delete, yank, and put commands, we can specify which register we want to interact with.
+
+**Addressing a Register**
+## "{register}
+>specify which register we want to use by prefixing the command with `"{register}`. If we don't specify a register, then Vim will use the **unnamed register**.
+
+**Vim's Terminology Versus the World**
+>1. Vim's **put** command is effectively identical to the **paste** operation. Both words begin with the letter **p**.
+>2. Vim's **yank** command is equivalent to the **copy** operation. Historically, the `c` command was already assigned to the **change** operation.
+>3. Vim's **delete** command is equivalent to the standard **cut** operation. It copies the specified text into a register and then removes if from the document.
+>4. Vim's **really deleing text** is `_` special register called the **black hole**, from which nothing returns.
+
+Normal commands:
+## "ayiw
+>yank the current word into register a.
+
+## "bdd
+>cut the current line into register b.
+
+## "ap
+>paste the word from register a.
+
+## "bp
+>paste the line from register b.
+
+Ex commands:
+## :delete c
+>cut the current line into register c.
+
+## :put c
+>paste it below the current line.
+
+**The Unnamed Register ("")**
+If we don't specify which register we want to interact with, then Vim will use the **unnamed register**, which is addressed by the " symbol.
+
+## ""p
+>to address this register explicitly, use two double quote marks. Which is effectively equivalent to `p`.
+
+The `x`, `s`, `d{motion}`, `c{motion}`, `y{motion}` commands and their uppercase equivalents all set the contents of the unnamed register. In each case, we can prefix `"{register}` to specify another register, but the unnamed register is the default.
+
+**The Yank Register ("0)**
+When we use the `y{motion}` command, the specified text is copied not only into the **unnamed register** but also into the **yank register**, which is addressed by the 0 symbol.
+
+The yank register is set **only** when we use the `y{motion}` command, it's not set by the `x`, `s`, `c{motion}`, `d{motion}`.
+
+![tip60_1](images/tip60_1.png)
+
+## diw
+>overwrites the unnamed register, but it leaves the yank register untouched.
+
+## "0P
+>pastes from the yank register.
+
+## :reg "0
+>inspect the contents of the unnamed and yank registers.
+
+**The Named Registers ("a-"z)**
+Vim has one named register for each letter of the alphabet. We can cut("ad{motion}), copy("ay{motion}), paste("ap) up to twenty-six pieces of text.
+
+![tip60_2](images/tip60_2.png)
+
+When we address a named register with a:
+>lowercase letter, it **overwrites** the specified register.
+>uppercase letter, it **appends** to the specified register.
+
+**The Black Hole Register("_)**
+The black hole register is a place from which nothing returns. It's addressed by the **underscore** symbol.
+
+## "_d{motion}
+>deletes the specified text without saving a copy of it.
+
+![tip60_3](images/tip60_3.png)
+
+**The System Clipboard("+) and Selection("*) Registers**
+All of the registers that we've discussed so far are internal to Vim.
+If we want to copy some text from inside of Vim and paste it into an external program, then we have to use one of the system clipboards.
+
+## "+
+>Vim's plus register references the system clipboard and is addressed by the + symbol.
+
+## "+p  &lt;C-r&gt;+
+>cut or copy command to capture text in an external application, you can paste it inside Vim using `"+p` command in Normal mode or `<C-r>+` from the Insert mode.
+
+![tip60_4](images/tip60_4.png)
+
+The X11 windowing system has a second kind of clipboard called the primary. This represents the **most recently selected text**.
+In Windows and Mac OS X, there is no primary clipboard.
+
+**The Expression Register("=)**
+Vim's registers can be thought of simply as **containers** that hold a block of text. The expression register = is and exception.
+When we fetch the contents of the expression register, Vim drops into **Command-Line** mode, showing an = prompt.
+We can enter a Vim script expression and press `<CR>` to execute it.
+
+**More Registers**
+Vim provides a handful of registers whose values are set **implicitly**. These are known collectively as the read-only registers.
+
+![tip60_5](images/tip60_5.png)
+
+Technically, the "/ register is not read-only, it can be set explicitly using the `:let` command.
+
 # [Tip59](tip59.md) [Tip61](tip61.md)

--- a/tip61.md
+++ b/tip61.md
@@ -1,4 +1,4 @@
-#Tip61: Replace a Visual Selection with a Register  
+# Tip61: Replace a Visual Selection with a Register  
   
 ![tip61_1](images/tip61_1.png)  
   
@@ -15,4 +15,4 @@ When we use the `p` command in Visual mode, Vim **replace the selection** with t
   
 Note: `m{char}`command sets a mark, and the `{char} command jumps to the mark.  
   
-#[Tip60](tip60.md) [Tip62](tip62.md)
+# [Tip60](tip60.md) [Tip62](tip62.md)

--- a/tip61.md
+++ b/tip61.md
@@ -1,18 +1,18 @@
-# Tip61: Replace a Visual Selection with a Register  
-  
-![tip61_1](images/tip61_1.png)  
-  
-When we use the `p` command in Visual mode, Vim **replace the selection** with the contents of the specified register.  
-  
-![tip61_2](images/tip61_2.png)  
-  
-**Swap Two Words**  
-![tip61_3](images/tip61_3.png)  
->`de` to cut the word "chips", copying it into the unnamed register.  
->Then we visually select the word **fish**, which we want to replace.  
->`p` put the word "chips" into the document, and the word "fish" is copied into the unnamed register.  
->Then we snap back to the gap and paste the word "fish" from the unnamed register back into the document.  
-  
-Note: `m{char}`command sets a mark, and the `{char} command jumps to the mark.  
-  
+# Tip61: Replace a Visual Selection with a Register
+
+![tip61_1](images/tip61_1.png)
+
+When we use the `p` command in Visual mode, Vim **replace the selection** with the contents of the specified register.
+
+![tip61_2](images/tip61_2.png)
+
+**Swap Two Words**
+![tip61_3](images/tip61_3.png)
+>`de` to cut the word "chips", copying it into the unnamed register.
+>Then we visually select the word **fish**, which we want to replace.
+>`p` put the word "chips" into the document, and the word "fish" is copied into the unnamed register.
+>Then we snap back to the gap and paste the word "fish" from the unnamed register back into the document.
+
+Note: `m{char}`command sets a mark, and the `{char} command jumps to the mark.
+
 # [Tip60](tip60.md) [Tip62](tip62.md)

--- a/tip62.md
+++ b/tip62.md
@@ -1,35 +1,35 @@
-# Tip62: Paste from a Register  
-## p  
->puts the text from a register **after** the cursor position.  
-  
-## P  
->puts the text from a register **before** the cursor position.  
-  
-**Pasting Character-wise Regions**  
-Whether we use the `p` or `P` command depends on where the cursor is positioned.  
-  
-![tip62_1](images/tip62_1.png)  
-  
-In the first case we would use `p`, whereas in the second case we would use `P`.  
-  
-## &lt;C-r&gt;{register}  
->paste Character-wise regions of text from Insert mode. The text from the register is always inserted **in front of** the cursor position.  
->`<C-r>"`: insert the contents of the **unnamed register**.  
->`<C-r>0`: insert the contents of the **yank register**.  
-  
-![tip62_2](images/tip62_2.png)  
-  
-**Pasting Line-Wise Regions**  
-## p P  
->put the text **before** or **after** the current line.  
-  
-## gp gP  
->put the text **below** or **above** the current line.  
->but they leave the cursor positioned **at the end** of the pasted text instead of at the **beginning**.  
-  
-![tip62_3](images/tip62_3.png)  
-  
-`P` would leave our cursor positioned **above** the inserted text.  
-`gP` would leave our cursor positioned on the **second duplicate**.  
-  
+# Tip62: Paste from a Register
+## p
+>puts the text from a register **after** the cursor position.
+
+## P
+>puts the text from a register **before** the cursor position.
+
+**Pasting Character-wise Regions**
+Whether we use the `p` or `P` command depends on where the cursor is positioned.
+
+![tip62_1](images/tip62_1.png)
+
+In the first case we would use `p`, whereas in the second case we would use `P`.
+
+## &lt;C-r&gt;{register}
+>paste Character-wise regions of text from Insert mode. The text from the register is always inserted **in front of** the cursor position.
+>`<C-r>"`: insert the contents of the **unnamed register**.
+>`<C-r>0`: insert the contents of the **yank register**.
+
+![tip62_2](images/tip62_2.png)
+
+**Pasting Line-Wise Regions**
+## p P
+>put the text **before** or **after** the current line.
+
+## gp gP
+>put the text **below** or **above** the current line.
+>but they leave the cursor positioned **at the end** of the pasted text instead of at the **beginning**.
+
+![tip62_3](images/tip62_3.png)
+
+`P` would leave our cursor positioned **above** the inserted text.
+`gP` would leave our cursor positioned on the **second duplicate**.
+
 # [Tip61](tip61.md) [Tip63](tip63.md)

--- a/tip62.md
+++ b/tip62.md
@@ -1,8 +1,8 @@
-#Tip62: Paste from a Register  
-##p  
+# Tip62: Paste from a Register  
+## p  
 >puts the text from a register **after** the cursor position.  
   
-##P  
+## P  
 >puts the text from a register **before** the cursor position.  
   
 **Pasting Character-wise Regions**  
@@ -12,7 +12,7 @@ Whether we use the `p` or `P` command depends on where the cursor is positioned.
   
 In the first case we would use `p`, whereas in the second case we would use `P`.  
   
-##&lt;C-r&gt;{register}  
+## &lt;C-r&gt;{register}  
 >paste Character-wise regions of text from Insert mode. The text from the register is always inserted **in front of** the cursor position.  
 >`<C-r>"`: insert the contents of the **unnamed register**.  
 >`<C-r>0`: insert the contents of the **yank register**.  
@@ -20,10 +20,10 @@ In the first case we would use `p`, whereas in the second case we would use `P`.
 ![tip62_2](images/tip62_2.png)  
   
 **Pasting Line-Wise Regions**  
-##p P  
+## p P  
 >put the text **before** or **after** the current line.  
   
-##gp gP  
+## gp gP  
 >put the text **below** or **above** the current line.  
 >but they leave the cursor positioned **at the end** of the pasted text instead of at the **beginning**.  
   
@@ -32,4 +32,4 @@ In the first case we would use `p`, whereas in the second case we would use `P`.
 `P` would leave our cursor positioned **above** the inserted text.  
 `gP` would leave our cursor positioned on the **second duplicate**.  
   
-#[Tip61](tip61.md) [Tip63](tip63.md)
+# [Tip61](tip61.md) [Tip63](tip63.md)

--- a/tip63.md
+++ b/tip63.md
@@ -1,4 +1,4 @@
-#Tip63: Interact with the System Clipboard  
+# Tip63: Interact with the System Clipboard  
 Besides Vim's built-in put commands, we can sometimes use the system paste command. However, using this can occasionally produce unexpected results when running Vim inside a terminal. We can avoid these issues by enabling the 'paste' option before using the system paste command.  
   
 When we use the system paste command in Insert mode, Vim acts as though each character has been typed by hand. When the 'autoindent' option is enabled, Vim preserves the same level of indentation each time we create a new line. The leading whitespace at the start of each line in the clipboard is added on top of the automatic indent, and the result is that each line wanders further and further to the right.  
@@ -7,10 +7,10 @@ GVim is able to discern when text is pasted from the clipboard and adjust its be
   
 When we're finished using the system paste command, we should disable the 'paste' option again. That means switching back to Normal mode and then running the Ex command `:set paste!`. Don't you think it would be handly if there were a way of toggling this option without leaving Insert mode?  
   
-##:set pastetoggle=&lt;f5&gt;  
+## :set pastetoggle=&lt;f5&gt;  
 >sets up the `<f5>` to toggle the paste option on and off.  
   
 **Avoid Toggling 'paste' by Putting from the Plus Register**  
 If you're running a version of Vim with system clipboard integration, then you can avoid fiddling with the 'paste' option entirely. The Normal mode `"+p` command pastes the contents of the plus register, which mirrors the system clipboard. This command preserves the indentation of the text in the clipboard so you can expect no surprises, regardless of how the 'paste' and 'autoindent' options are set.  
   
-#[Tip62](tip62.md) [Tip64](tip64.md)
+# [Tip62](tip62.md) [Tip64](tip64.md)

--- a/tip63.md
+++ b/tip63.md
@@ -1,16 +1,16 @@
-# Tip63: Interact with the System Clipboard  
-Besides Vim's built-in put commands, we can sometimes use the system paste command. However, using this can occasionally produce unexpected results when running Vim inside a terminal. We can avoid these issues by enabling the 'paste' option before using the system paste command.  
-  
-When we use the system paste command in Insert mode, Vim acts as though each character has been typed by hand. When the 'autoindent' option is enabled, Vim preserves the same level of indentation each time we create a new line. The leading whitespace at the start of each line in the clipboard is added on top of the automatic indent, and the result is that each line wanders further and further to the right.  
-  
-GVim is able to discern when text is pasted from the clipboard and adjust its behavior accordingly, but when Vim runs inside a terminal this information is not available. The 'paste' option allows us to manually warn Vim that we're about to use the system paste command. When the 'paste' option is enabled, Vim turns off all Insert mode mappings and abbreviations and resets a host of options, including 'autoindent'. That allows us to safely paste from the system clipboard with no surprises.  
-  
-When we're finished using the system paste command, we should disable the 'paste' option again. That means switching back to Normal mode and then running the Ex command `:set paste!`. Don't you think it would be handly if there were a way of toggling this option without leaving Insert mode?  
-  
-## :set pastetoggle=&lt;f5&gt;  
->sets up the `<f5>` to toggle the paste option on and off.  
-  
-**Avoid Toggling 'paste' by Putting from the Plus Register**  
-If you're running a version of Vim with system clipboard integration, then you can avoid fiddling with the 'paste' option entirely. The Normal mode `"+p` command pastes the contents of the plus register, which mirrors the system clipboard. This command preserves the indentation of the text in the clipboard so you can expect no surprises, regardless of how the 'paste' and 'autoindent' options are set.  
-  
+# Tip63: Interact with the System Clipboard
+Besides Vim's built-in put commands, we can sometimes use the system paste command. However, using this can occasionally produce unexpected results when running Vim inside a terminal. We can avoid these issues by enabling the 'paste' option before using the system paste command.
+
+When we use the system paste command in Insert mode, Vim acts as though each character has been typed by hand. When the 'autoindent' option is enabled, Vim preserves the same level of indentation each time we create a new line. The leading whitespace at the start of each line in the clipboard is added on top of the automatic indent, and the result is that each line wanders further and further to the right.
+
+GVim is able to discern when text is pasted from the clipboard and adjust its behavior accordingly, but when Vim runs inside a terminal this information is not available. The 'paste' option allows us to manually warn Vim that we're about to use the system paste command. When the 'paste' option is enabled, Vim turns off all Insert mode mappings and abbreviations and resets a host of options, including 'autoindent'. That allows us to safely paste from the system clipboard with no surprises.
+
+When we're finished using the system paste command, we should disable the 'paste' option again. That means switching back to Normal mode and then running the Ex command `:set paste!`. Don't you think it would be handly if there were a way of toggling this option without leaving Insert mode?
+
+## :set pastetoggle=&lt;f5&gt;
+>sets up the `<f5>` to toggle the paste option on and off.
+
+**Avoid Toggling 'paste' by Putting from the Plus Register**
+If you're running a version of Vim with system clipboard integration, then you can avoid fiddling with the 'paste' option entirely. The Normal mode `"+p` command pastes the contents of the plus register, which mirrors the system clipboard. This command preserves the indentation of the text in the clipboard so you can expect no surprises, regardless of how the 'paste' and 'autoindent' options are set.
+
 # [Tip62](tip62.md) [Tip64](tip64.md)

--- a/tip64.md
+++ b/tip64.md
@@ -1,50 +1,50 @@
-# Tip64: Record and Execute a Macro  
-  
-Vim offers more than one way to repeat changes. Dot and Macros.  
->dot is useful for repeating small changes.  
->macro is useful for repeating anything more substantial. We can **record** any number of keystrokes into a **register** and then play them back.  
-  
-Macros are ideal for repeating changes over a set of similar lines, paragraphs, or even files.  
-There are two ways of executing a macro across a set of targets:  
->playing it back in series  
->running it multiple times in parallel  
+# Tip64: Record and Execute a Macro
 
-Macros allow us to record a sequence of changes and then play them back.  
-  
-Many repetitive tasks involve making multiple changes. If we want to automate these, we can record a macro and then execute it.  
-  
-**Capture a Sequence of Commands by Recording a Macro**  
-## q  
->q key functions both as the "record" button and the "stop" button.  
-  
-## q{register}  
->begin recording our keystrokes, giving the address of the register where we want to save the macro.  
-  
-## qa  
->begins recording and saves our macro into register a.  
->Then we make changes on the first line: ; var  
->press `q` to stop recording our macro.  
-  
-## :reg a  
->inspect the contents of register a.  
-  
-![tip64_1](images/tip64_1.png)  
-  
-**Play Back a Sequence of Commands by Executing a Macro**  
-## @{register}  
->executes the contents of the specified register.  
-  
-## @@  
->repeats the macro that was invoked most recently.  
-  
-![tip64_2](images/tip64_2.png)  
-  
-**Execute the Macro in Series**  
+Vim offers more than one way to repeat changes. Dot and Macros.
+>dot is useful for repeating small changes.
+>macro is useful for repeating anything more substantial. We can **record** any number of keystrokes into a **register** and then play them back.
 
-**Execute the Macro in Parallel**  
-  
-Under the hood, Vim always executes macros **sequentially**, no matter which of these two techniques we use. The term in parallel is intended to draw an analogy with the robustness of parallel circuits. It is not meant to suggest that Vim executes multiple changes concurrently.  
-  
+Macros are ideal for repeating changes over a set of similar lines, paragraphs, or even files.
+There are two ways of executing a macro across a set of targets:
+>playing it back in series
+>running it multiple times in parallel
+
+Macros allow us to record a sequence of changes and then play them back.
+
+Many repetitive tasks involve making multiple changes. If we want to automate these, we can record a macro and then execute it.
+
+**Capture a Sequence of Commands by Recording a Macro**
+## q
+>q key functions both as the "record" button and the "stop" button.
+
+## q{register}
+>begin recording our keystrokes, giving the address of the register where we want to save the macro.
+
+## qa
+>begins recording and saves our macro into register a.
+>Then we make changes on the first line: ; var
+>press `q` to stop recording our macro.
+
+## :reg a
+>inspect the contents of register a.
+
+![tip64_1](images/tip64_1.png)
+
+**Play Back a Sequence of Commands by Executing a Macro**
+## @{register}
+>executes the contents of the specified register.
+
+## @@
+>repeats the macro that was invoked most recently.
+
+![tip64_2](images/tip64_2.png)
+
+**Execute the Macro in Series**
+
+**Execute the Macro in Parallel**
+
+Under the hood, Vim always executes macros **sequentially**, no matter which of these two techniques we use. The term in parallel is intended to draw an analogy with the robustness of parallel circuits. It is not meant to suggest that Vim executes multiple changes concurrently.
+
 # [Tip63](tip63.md) [Tip65](tip65.md)
 
 

--- a/tip64.md
+++ b/tip64.md
@@ -1,4 +1,4 @@
-#Tip64: Record and Execute a Macro  
+# Tip64: Record and Execute a Macro  
   
 Vim offers more than one way to repeat changes. Dot and Macros.  
 >dot is useful for repeating small changes.  
@@ -14,27 +14,27 @@ Macros allow us to record a sequence of changes and then play them back.
 Many repetitive tasks involve making multiple changes. If we want to automate these, we can record a macro and then execute it.  
   
 **Capture a Sequence of Commands by Recording a Macro**  
-##q  
+## q  
 >q key functions both as the "record" button and the "stop" button.  
   
-##q{register}  
+## q{register}  
 >begin recording our keystrokes, giving the address of the register where we want to save the macro.  
   
-##qa  
+## qa  
 >begins recording and saves our macro into register a.  
 >Then we make changes on the first line: ; var  
 >press `q` to stop recording our macro.  
   
-##:reg a  
+## :reg a  
 >inspect the contents of register a.  
   
 ![tip64_1](images/tip64_1.png)  
   
 **Play Back a Sequence of Commands by Executing a Macro**  
-##@{register}  
+## @{register}  
 >executes the contents of the specified register.  
   
-##@@  
+## @@  
 >repeats the macro that was invoked most recently.  
   
 ![tip64_2](images/tip64_2.png)  
@@ -45,6 +45,6 @@ Many repetitive tasks involve making multiple changes. If we want to automate th
   
 Under the hood, Vim always executes macros **sequentially**, no matter which of these two techniques we use. The term in parallel is intended to draw an analogy with the robustness of parallel circuits. It is not meant to suggest that Vim executes multiple changes concurrently.  
   
-#[Tip63](tip63.md) [Tip65](tip65.md)
+# [Tip63](tip63.md) [Tip65](tip65.md)
 
 

--- a/tip65.md
+++ b/tip65.md
@@ -1,21 +1,21 @@
-# Tip65: Normalize, Strike, Abort  
-Executing a macro can sometimes produce unexpected results, but we can achieve better consistency if we follow a handful of best practices.  
-  
-When we execute a macro, Vim blindly repeats the sequence of canned keystrokes.  
-  
-The golden rule is this: when recording a macro, ensure that every command is repeatable.  
-  
-**Normalize the Cursor Position**  
-Before you do anything, make sure your cursor is positioned so that the next command does what you expect, where you expect it.  
-  
-**Strike Your Target with a Repeatable Motion**  
-Word-wise motions, such as `w`, `b`, `e` and `ge` tend to be more flexible than character-wise `h` and `l` motions.  
-Don't forget: when recording a macro, using the mouse is **verboten**.  
-  
-**Abort When a Motion Fails**  
-If a motion fails while a macro is executing, then Vim aborts the rest of the macro.  
-  
-## number@a  
->rather than executing `@a` ten times. We could prefix it with a count: `10@a`.  
-  
+# Tip65: Normalize, Strike, Abort
+Executing a macro can sometimes produce unexpected results, but we can achieve better consistency if we follow a handful of best practices.
+
+When we execute a macro, Vim blindly repeats the sequence of canned keystrokes.
+
+The golden rule is this: when recording a macro, ensure that every command is repeatable.
+
+**Normalize the Cursor Position**
+Before you do anything, make sure your cursor is positioned so that the next command does what you expect, where you expect it.
+
+**Strike Your Target with a Repeatable Motion**
+Word-wise motions, such as `w`, `b`, `e` and `ge` tend to be more flexible than character-wise `h` and `l` motions.
+Don't forget: when recording a macro, using the mouse is **verboten**.
+
+**Abort When a Motion Fails**
+If a motion fails while a macro is executing, then Vim aborts the rest of the macro.
+
+## number@a
+>rather than executing `@a` ten times. We could prefix it with a count: `10@a`.
+
 # [Tip64](tip64.md) [Tip66](tip66.md)

--- a/tip65.md
+++ b/tip65.md
@@ -1,4 +1,4 @@
-#Tip65: Normalize, Strike, Abort  
+# Tip65: Normalize, Strike, Abort  
 Executing a macro can sometimes produce unexpected results, but we can achieve better consistency if we follow a handful of best practices.  
   
 When we execute a macro, Vim blindly repeats the sequence of canned keystrokes.  
@@ -15,7 +15,7 @@ Don't forget: when recording a macro, using the mouse is **verboten**.
 **Abort When a Motion Fails**  
 If a motion fails while a macro is executing, then Vim aborts the rest of the macro.  
   
-##number@a  
+## number@a  
 >rather than executing `@a` ten times. We could prefix it with a count: `10@a`.  
   
-#[Tip64](tip64.md) [Tip66](tip66.md)
+# [Tip64](tip64.md) [Tip66](tip66.md)

--- a/tip66.md
+++ b/tip66.md
@@ -1,17 +1,17 @@
-# Tip66: Play Back with a Count  
-The dot Formula can be an efficient editing strategy for a small number of repeats, but it can't be executed with a count. Overcome this limitation by recording a cheap one-off macro and playing it back with a count.  
-  
-## qq;.q  
->`qq` tells Vim to record the following keystrokes and save them to the q register.  
->`;.` our commands.  
->`q` finish recording the macro.  
-  
-The `;` command repeats the `f+` search. When our cursor is positioned after the last + character on the line, the `;` motion fails and the macro aborts.  
-  
-![tip66](images/tip66.png)  
-  
-In our case, we want to execute the macro ten times. But if we were to play it back eleven times, the final execution would abort.  
-In other words, we can complete the task so long as we invoke the macro with a count of ten or more.  
-I often use 22, because I'm lazy and it's easy to type.  
-  
+# Tip66: Play Back with a Count
+The dot Formula can be an efficient editing strategy for a small number of repeats, but it can't be executed with a count. Overcome this limitation by recording a cheap one-off macro and playing it back with a count.
+
+## qq;.q
+>`qq` tells Vim to record the following keystrokes and save them to the q register.
+>`;.` our commands.
+>`q` finish recording the macro.
+
+The `;` command repeats the `f+` search. When our cursor is positioned after the last + character on the line, the `;` motion fails and the macro aborts.
+
+![tip66](images/tip66.png)
+
+In our case, we want to execute the macro ten times. But if we were to play it back eleven times, the final execution would abort.
+In other words, we can complete the task so long as we invoke the macro with a count of ten or more.
+I often use 22, because I'm lazy and it's easy to type.
+
 # [Tip65](tip65.md) [Tip67](tip67.md)

--- a/tip66.md
+++ b/tip66.md
@@ -1,7 +1,7 @@
-#Tip66: Play Back with a Count  
+# Tip66: Play Back with a Count  
 The dot Formula can be an efficient editing strategy for a small number of repeats, but it can't be executed with a count. Overcome this limitation by recording a cheap one-off macro and playing it back with a count.  
   
-##qq;.q  
+## qq;.q  
 >`qq` tells Vim to record the following keystrokes and save them to the q register.  
 >`;.` our commands.  
 >`q` finish recording the macro.  
@@ -14,4 +14,4 @@ In our case, we want to execute the macro ten times. But if we were to play it b
 In other words, we can complete the task so long as we invoke the macro with a count of ten or more.  
 I often use 22, because I'm lazy and it's easy to type.  
   
-#[Tip65](tip65.md) [Tip67](tip67.md)
+# [Tip65](tip65.md) [Tip67](tip67.md)

--- a/tip67.md
+++ b/tip67.md
@@ -1,33 +1,33 @@
-# Tip67: Repeat a Change on Contiguous Lines  
-We want to make a change: 
-![tip67_1](images/tip67_1.png)  
-![tip67_2](images/tip67_2.png)  
-  
-**Record One Unit of Work**  
-  
-![tip67_3](images/tip67_3.png)  
-  
-## 0  
->normalizes our cursor position by placing it at the start of the line. This means that our next motion always starts from the same place, making it more repeatable.  
-  
-Note: `f.` is more repeatability than `l`  
-  
-**Execute Macro in Series**  
-![tip67_4](images/tip67_4.png)  
-  
-![tip67_5](images/tip67_5.png)  
-  
-When the `f.` command is executed, it finds no . characters and the macro aborts.  
-  
-![tip67_6](images/tip67_6.png)  
-  
-**Execute Macro in Parallel**  
-![tip67_7](images/tip67_7.png)  
-  
-## :normal @a  
->tells Vim to execute the macro once for each line in the selection.  
-  
-**Deciding: Series or Parallel**  
-Executing a macro on multiple items in parallel is more robust.  
-  
+# Tip67: Repeat a Change on Contiguous Lines
+We want to make a change:
+![tip67_1](images/tip67_1.png)
+![tip67_2](images/tip67_2.png)
+
+**Record One Unit of Work**
+
+![tip67_3](images/tip67_3.png)
+
+## 0
+>normalizes our cursor position by placing it at the start of the line. This means that our next motion always starts from the same place, making it more repeatable.
+
+Note: `f.` is more repeatability than `l`
+
+**Execute Macro in Series**
+![tip67_4](images/tip67_4.png)
+
+![tip67_5](images/tip67_5.png)
+
+When the `f.` command is executed, it finds no . characters and the macro aborts.
+
+![tip67_6](images/tip67_6.png)
+
+**Execute Macro in Parallel**
+![tip67_7](images/tip67_7.png)
+
+## :normal @a
+>tells Vim to execute the macro once for each line in the selection.
+
+**Deciding: Series or Parallel**
+Executing a macro on multiple items in parallel is more robust.
+
 # [Tip66](tip66.md) [Tip68](tip68.md)

--- a/tip67.md
+++ b/tip67.md
@@ -1,4 +1,4 @@
-#Tip67: Repeat a Change on Contiguous Lines  
+# Tip67: Repeat a Change on Contiguous Lines  
 We want to make a change: 
 ![tip67_1](images/tip67_1.png)  
 ![tip67_2](images/tip67_2.png)  
@@ -7,7 +7,7 @@ We want to make a change:
   
 ![tip67_3](images/tip67_3.png)  
   
-##0  
+## 0  
 >normalizes our cursor position by placing it at the start of the line. This means that our next motion always starts from the same place, making it more repeatable.  
   
 Note: `f.` is more repeatability than `l`  
@@ -24,10 +24,10 @@ When the `f.` command is executed, it finds no . characters and the macro aborts
 **Execute Macro in Parallel**  
 ![tip67_7](images/tip67_7.png)  
   
-##:normal @a  
+## :normal @a  
 >tells Vim to execute the macro once for each line in the selection.  
   
 **Deciding: Series or Parallel**  
 Executing a macro on multiple items in parallel is more robust.  
   
-#[Tip66](tip66.md) [Tip68](tip68.md)
+# [Tip66](tip66.md) [Tip68](tip68.md)

--- a/tip68.md
+++ b/tip68.md
@@ -1,21 +1,21 @@
-# Tip68: Append Commands to a Macro  
-Sometimes we miss a vital step when we record a macro. There's no need to re-record the whole thing from scratch. Instead, we can tack extra commands onto the **end** of an existing macro.  
-![tip68_1](images/tip68_1.png)  
-  
-We realize that we should have finished by pressing `j` to advance to the next line.  
-  
-Before we fix it, let's inspect the contents of register a:  
-![tip68_2](images/tip68_2.png)  
-  
-## qa  
->Vim will record our keystrokes, saving them into register a by overwriting the existing contents of that register.  
-  
-## qA  
->Vim will record our keystrokes, **appending** them to the existing contents of register a.  
-  
-![tip68_3](images/tip68_3.png)  
-  
-**Discussion**  
-We can use this tech only to tack commands on at the **end** of a macro. If you want to add something at the beginning or somewhere in the middle of a macro, this technique would be no use to you!  
-  
+# Tip68: Append Commands to a Macro
+Sometimes we miss a vital step when we record a macro. There's no need to re-record the whole thing from scratch. Instead, we can tack extra commands onto the **end** of an existing macro.
+![tip68_1](images/tip68_1.png)
+
+We realize that we should have finished by pressing `j` to advance to the next line.
+
+Before we fix it, let's inspect the contents of register a:
+![tip68_2](images/tip68_2.png)
+
+## qa
+>Vim will record our keystrokes, saving them into register a by overwriting the existing contents of that register.
+
+## qA
+>Vim will record our keystrokes, **appending** them to the existing contents of register a.
+
+![tip68_3](images/tip68_3.png)
+
+**Discussion**
+We can use this tech only to tack commands on at the **end** of a macro. If you want to add something at the beginning or somewhere in the middle of a macro, this technique would be no use to you!
+
 # [Tip67](tip67.md) [Tip69](tip69.md)

--- a/tip68.md
+++ b/tip68.md
@@ -1,4 +1,4 @@
-#Tip68: Append Commands to a Macro  
+# Tip68: Append Commands to a Macro  
 Sometimes we miss a vital step when we record a macro. There's no need to re-record the whole thing from scratch. Instead, we can tack extra commands onto the **end** of an existing macro.  
 ![tip68_1](images/tip68_1.png)  
   
@@ -7,10 +7,10 @@ We realize that we should have finished by pressing `j` to advance to the next l
 Before we fix it, let's inspect the contents of register a:  
 ![tip68_2](images/tip68_2.png)  
   
-##qa  
+## qa  
 >Vim will record our keystrokes, saving them into register a by overwriting the existing contents of that register.  
   
-##qA  
+## qA  
 >Vim will record our keystrokes, **appending** them to the existing contents of register a.  
   
 ![tip68_3](images/tip68_3.png)  
@@ -18,4 +18,4 @@ Before we fix it, let's inspect the contents of register a:
 **Discussion**  
 We can use this tech only to tack commands on at the **end** of a macro. If you want to add something at the beginning or somewhere in the middle of a macro, this technique would be no use to you!  
   
-#[Tip67](tip67.md) [Tip69](tip69.md)
+# [Tip67](tip67.md) [Tip69](tip69.md)

--- a/tip69.md
+++ b/tip69.md
@@ -1,46 +1,46 @@
-# Tip69: Act Upon a Collection of Files  
-So far, we've stuck to tasks that were repeated in the same file, but we can play back a macro across a collection of files. Once again, we'll consider how to execute the macro in parallel and in series.  
-  
-![tip69_1](images/tip69_1.png)  
-  
-**Preparation**  
-**Build a List of Target Files**  
-![tip69_2](images/tip69_2.png)  
-  
-**Record a Unit of Work**  
-![tip69_3](images/tip69_3.png)  
-  
-![tip69_4](images/tip69_4.png)  
-  
-## gg/class&lt;CR&gt;  
->`gg` places the cursor at the start of the file.  
->`/class<CR>` jumps forwards to the first occurrence of the word "class".  
-  
-**Execute the Macro in Parallel**  
-## :argdo  
->allow us to execute an Ex command once for **each buffer** in the argument list.  
-  
-## :edit!  
->revert all of the changes we just made to the first buffer in the argument list.  
-  
-## :argdo normal @a  
->execute the macro in all of the buffers in the argument list.  
-  
-**Execute the Macro in Series**  
-Our macro performs a single unit of work on a single buffer. If we want to make it act upon multiple buffers, we could append a final step that advances to the next buffer in the list.  
-Then we can run `3@a` to execute the macro on each of the remaining files in the buffer list. When we reach the last buffer in the argument list, the `:next` command fails and the macro aborts.  
-  
-![tip69_5](images/tip69_5.png)  
-  
-**Save Changes to All Files**  
-We've changed four files, but we haven't saved any of them.  
-## :argdo write  
->save all files in the argument list.  
-  
-## :wall  
->save all files in the buffer list, quicker to save all files.  
-  
-## :wnext  
->:write followed by :next  
-  
+# Tip69: Act Upon a Collection of Files
+So far, we've stuck to tasks that were repeated in the same file, but we can play back a macro across a collection of files. Once again, we'll consider how to execute the macro in parallel and in series.
+
+![tip69_1](images/tip69_1.png)
+
+**Preparation**
+**Build a List of Target Files**
+![tip69_2](images/tip69_2.png)
+
+**Record a Unit of Work**
+![tip69_3](images/tip69_3.png)
+
+![tip69_4](images/tip69_4.png)
+
+## gg/class&lt;CR&gt;
+>`gg` places the cursor at the start of the file.
+>`/class<CR>` jumps forwards to the first occurrence of the word "class".
+
+**Execute the Macro in Parallel**
+## :argdo
+>allow us to execute an Ex command once for **each buffer** in the argument list.
+
+## :edit!
+>revert all of the changes we just made to the first buffer in the argument list.
+
+## :argdo normal @a
+>execute the macro in all of the buffers in the argument list.
+
+**Execute the Macro in Series**
+Our macro performs a single unit of work on a single buffer. If we want to make it act upon multiple buffers, we could append a final step that advances to the next buffer in the list.
+Then we can run `3@a` to execute the macro on each of the remaining files in the buffer list. When we reach the last buffer in the argument list, the `:next` command fails and the macro aborts.
+
+![tip69_5](images/tip69_5.png)
+
+**Save Changes to All Files**
+We've changed four files, but we haven't saved any of them.
+## :argdo write
+>save all files in the argument list.
+
+## :wall
+>save all files in the buffer list, quicker to save all files.
+
+## :wnext
+>:write followed by :next
+
 # [Tip68](tip68.md) [Tip70](tip70.md)

--- a/tip69.md
+++ b/tip69.md
@@ -1,4 +1,4 @@
-#Tip69: Act Upon a Collection of Files  
+# Tip69: Act Upon a Collection of Files  
 So far, we've stuck to tasks that were repeated in the same file, but we can play back a macro across a collection of files. Once again, we'll consider how to execute the macro in parallel and in series.  
   
 ![tip69_1](images/tip69_1.png)  
@@ -12,18 +12,18 @@ So far, we've stuck to tasks that were repeated in the same file, but we can pla
   
 ![tip69_4](images/tip69_4.png)  
   
-##gg/class&lt;CR&gt;  
+## gg/class&lt;CR&gt;  
 >`gg` places the cursor at the start of the file.  
 >`/class<CR>` jumps forwards to the first occurrence of the word "class".  
   
 **Execute the Macro in Parallel**  
-##:argdo  
+## :argdo  
 >allow us to execute an Ex command once for **each buffer** in the argument list.  
   
-##:edit!  
+## :edit!  
 >revert all of the changes we just made to the first buffer in the argument list.  
   
-##:argdo normal @a  
+## :argdo normal @a  
 >execute the macro in all of the buffers in the argument list.  
   
 **Execute the Macro in Series**  
@@ -34,13 +34,13 @@ Then we can run `3@a` to execute the macro on each of the remaining files in the
   
 **Save Changes to All Files**  
 We've changed four files, but we haven't saved any of them.  
-##:argdo write  
+## :argdo write  
 >save all files in the argument list.  
   
-##:wall  
+## :wall  
 >save all files in the buffer list, quicker to save all files.  
   
-##:wnext  
+## :wnext  
 >:write followed by :next  
   
-#[Tip68](tip68.md) [Tip70](tip70.md)
+# [Tip68](tip68.md) [Tip70](tip70.md)

--- a/tip7.md
+++ b/tip7.md
@@ -1,5 +1,5 @@
-#Tip7: Pause with Your Brush Off the Page  
+# Tip7: Pause with Your Brush Off the Page  
   
 Just as painters spend a fraction of their time applying paint, programmers spend a fraction of their time composing code. **More time is spent thinking, reading, and navigating from one part of a codebase to another.** And when we do want to make a change, who says we have to switch to Insert mode? We can reformat existing code, duplicate it, move it around, or delete it. **From Normal mode**, we have many tools at our disposal.  
   
-#[Tip6](tip6.md)  [Tip8](tip8.md)
+# [Tip6](tip6.md)  [Tip8](tip8.md)

--- a/tip7.md
+++ b/tip7.md
@@ -1,5 +1,5 @@
-# Tip7: Pause with Your Brush Off the Page  
-  
-Just as painters spend a fraction of their time applying paint, programmers spend a fraction of their time composing code. **More time is spent thinking, reading, and navigating from one part of a codebase to another.** And when we do want to make a change, who says we have to switch to Insert mode? We can reformat existing code, duplicate it, move it around, or delete it. **From Normal mode**, we have many tools at our disposal.  
-  
+# Tip7: Pause with Your Brush Off the Page
+
+Just as painters spend a fraction of their time applying paint, programmers spend a fraction of their time composing code. **More time is spent thinking, reading, and navigating from one part of a codebase to another.** And when we do want to make a change, who says we have to switch to Insert mode? We can reformat existing code, duplicate it, move it around, or delete it. **From Normal mode**, we have many tools at our disposal.
+
 # [Tip6](tip6.md)  [Tip8](tip8.md)

--- a/tip70.md
+++ b/tip70.md
@@ -1,16 +1,16 @@
-#Tip70: Evaluate an Iterator to Number Items in a List  
+# Tip70: Evaluate an Iterator to Number Items in a List  
 Being able to insert a value that changes for each execution of a macro can be useful. In this tip, we'll learn a technique for incrementing a number as we record a macro so that we can insert the numbers 1 to 5 on consecutive lines.  
   
 ![tip70_1](images/tip70_1.png)  
   
 **Rudimentary Vim Script**  
-##:let i=0  
+## :let i=0  
 >create a variable called i and assign it a value of 0.  
   
-##:echo i  
+## :echo i  
 >allows us to inspect the current value assigned to a variable.  
   
-##&lt;C-r&gt;=i&lt;CR&gt;  
+## &lt;C-r&gt;=i&lt;CR&gt;  
 >insert the value stored in variable.  
   
 **Record the Macro**  
@@ -19,8 +19,8 @@ Being able to insert a value that changes for each execution of a macro can be u
 **Execute the Macro**  
 ![tip70_3](images/tip70_3.png)  
   
-##:normal @a  
+## :normal @a  
 >tells Vim to execute the macro on each of the selected lines.  
 >the value of i gets incremented each time the macro executes.  
   
-#[Tip69](tip69.md) [Tip71](tip71.md)
+# [Tip69](tip69.md) [Tip71](tip71.md)

--- a/tip70.md
+++ b/tip70.md
@@ -1,26 +1,26 @@
-# Tip70: Evaluate an Iterator to Number Items in a List  
-Being able to insert a value that changes for each execution of a macro can be useful. In this tip, we'll learn a technique for incrementing a number as we record a macro so that we can insert the numbers 1 to 5 on consecutive lines.  
-  
-![tip70_1](images/tip70_1.png)  
-  
-**Rudimentary Vim Script**  
-## :let i=0  
->create a variable called i and assign it a value of 0.  
-  
-## :echo i  
->allows us to inspect the current value assigned to a variable.  
-  
-## &lt;C-r&gt;=i&lt;CR&gt;  
->insert the value stored in variable.  
-  
-**Record the Macro**  
-![tip70_2](images/tip70_2.png)  
-  
-**Execute the Macro**  
-![tip70_3](images/tip70_3.png)  
-  
-## :normal @a  
->tells Vim to execute the macro on each of the selected lines.  
->the value of i gets incremented each time the macro executes.  
-  
+# Tip70: Evaluate an Iterator to Number Items in a List
+Being able to insert a value that changes for each execution of a macro can be useful. In this tip, we'll learn a technique for incrementing a number as we record a macro so that we can insert the numbers 1 to 5 on consecutive lines.
+
+![tip70_1](images/tip70_1.png)
+
+**Rudimentary Vim Script**
+## :let i=0
+>create a variable called i and assign it a value of 0.
+
+## :echo i
+>allows us to inspect the current value assigned to a variable.
+
+## &lt;C-r&gt;=i&lt;CR&gt;
+>insert the value stored in variable.
+
+**Record the Macro**
+![tip70_2](images/tip70_2.png)
+
+**Execute the Macro**
+![tip70_3](images/tip70_3.png)
+
+## :normal @a
+>tells Vim to execute the macro on each of the selected lines.
+>the value of i gets incremented each time the macro executes.
+
 # [Tip69](tip69.md) [Tip71](tip71.md)

--- a/tip71.md
+++ b/tip71.md
@@ -1,15 +1,15 @@
-#Tip71: Edit the Contents of a Macro  
+# Tip71: Edit the Contents of a Macro  
 **The Problem: Nonstandard Formatting**  
 ![tip71_1](images/tip71_1.png)  
   
-##~  
+## ~  
 >toggles the case of the letter under the cursor.  
   
-##vU  
+## vU  
 >uppercase the letter under the cursor.  
   
 **Paste the Macro into a Document**  
-##:put a  
+## :put a  
 >paste the macro into the document(below the current line).  
 >`"ap` paste the contents of a register after the cursor position on the current line.  
   
@@ -17,18 +17,18 @@
 ![tip71_2](images/tip71_2.png)  
   
 **Yank the Macro from the Document Back into a Register**  
-##"add  
+## "add  
 >the dd command performs a line-wise deletion, the register contains a trailing ^J character.  
 >this character represents a newline.  
   
 As a precaution, using a character-wise yank:  
 ![tip71_3](images/tip71_3.png)  
   
-##"ay$  
+## "ay$  
 >yank every character on that line except for the carriage return.  
   
 **Discussion**  
-##:let @a=substitute(@a, '\~', 'vU', 'g')  
+## :let @a=substitute(@a, '\~', 'vU', 'g')  
 >perform the same edit as before.  
   
-#[Tip70](tip70.md) [Tip72](tip72.md)
+# [Tip70](tip70.md) [Tip72](tip72.md)

--- a/tip71.md
+++ b/tip71.md
@@ -1,34 +1,34 @@
-# Tip71: Edit the Contents of a Macro  
-**The Problem: Nonstandard Formatting**  
-![tip71_1](images/tip71_1.png)  
-  
-## ~  
->toggles the case of the letter under the cursor.  
-  
-## vU  
->uppercase the letter under the cursor.  
-  
-**Paste the Macro into a Document**  
-## :put a  
->paste the macro into the document(below the current line).  
->`"ap` paste the contents of a register after the cursor position on the current line.  
-  
-**Edit the Text**  
-![tip71_2](images/tip71_2.png)  
-  
-**Yank the Macro from the Document Back into a Register**  
-## "add  
->the dd command performs a line-wise deletion, the register contains a trailing ^J character.  
->this character represents a newline.  
-  
-As a precaution, using a character-wise yank:  
-![tip71_3](images/tip71_3.png)  
-  
-## "ay$  
->yank every character on that line except for the carriage return.  
-  
-**Discussion**  
-## :let @a=substitute(@a, '\~', 'vU', 'g')  
->perform the same edit as before.  
-  
+# Tip71: Edit the Contents of a Macro
+**The Problem: Nonstandard Formatting**
+![tip71_1](images/tip71_1.png)
+
+## ~
+>toggles the case of the letter under the cursor.
+
+## vU
+>uppercase the letter under the cursor.
+
+**Paste the Macro into a Document**
+## :put a
+>paste the macro into the document(below the current line).
+>`"ap` paste the contents of a register after the cursor position on the current line.
+
+**Edit the Text**
+![tip71_2](images/tip71_2.png)
+
+**Yank the Macro from the Document Back into a Register**
+## "add
+>the dd command performs a line-wise deletion, the register contains a trailing ^J character.
+>this character represents a newline.
+
+As a precaution, using a character-wise yank:
+![tip71_3](images/tip71_3.png)
+
+## "ay$
+>yank every character on that line except for the carriage return.
+
+**Discussion**
+## :let @a=substitute(@a, '\~', 'vU', 'g')
+>perform the same edit as before.
+
 # [Tip70](tip70.md) [Tip72](tip72.md)

--- a/tip72.md
+++ b/tip72.md
@@ -1,17 +1,17 @@
-# Tip72: Tune the Case Sensitivity of Search Patterns  
-  
-We can tune the case sensitivity of Vim's search globally or on a per-search basis.  
-  
-**Setting Case Sensitivity Globally**  
-We can make Vim's search patterns **case insensitive** by enabling the 'ignorecase' setting. But this setting has a side effect that influences the behavior of Vim's keyword autocompletion.  
-  
-**Setting Case Sensitivity per Search**  
->`\c`: causes the search pattern to **ignore case**.  
->`\C`: forces case sensitivity.  
-  
-**Enabling Smarter Default Case Sensitivity**  
-## 'smartcase'  
->If our pattern include an uppercase character, 'smartcase' canceling out the 'ignorecase'.  
->If our pattern include all lowercase, the search will be case insensitive.  
-  
+# Tip72: Tune the Case Sensitivity of Search Patterns
+
+We can tune the case sensitivity of Vim's search globally or on a per-search basis.
+
+**Setting Case Sensitivity Globally**
+We can make Vim's search patterns **case insensitive** by enabling the 'ignorecase' setting. But this setting has a side effect that influences the behavior of Vim's keyword autocompletion.
+
+**Setting Case Sensitivity per Search**
+>`\c`: causes the search pattern to **ignore case**.
+>`\C`: forces case sensitivity.
+
+**Enabling Smarter Default Case Sensitivity**
+## 'smartcase'
+>If our pattern include an uppercase character, 'smartcase' canceling out the 'ignorecase'.
+>If our pattern include all lowercase, the search will be case insensitive.
+
 # [Tip71](tip71.md) [Tip73](tip73.md)

--- a/tip72.md
+++ b/tip72.md
@@ -1,4 +1,4 @@
-#Tip72: Tune the Case Sensitivity of Search Patterns  
+# Tip72: Tune the Case Sensitivity of Search Patterns  
   
 We can tune the case sensitivity of Vim's search globally or on a per-search basis.  
   
@@ -10,8 +10,8 @@ We can make Vim's search patterns **case insensitive** by enabling the 'ignoreca
 >`\C`: forces case sensitivity.  
   
 **Enabling Smarter Default Case Sensitivity**  
-##'smartcase'  
+## 'smartcase'  
 >If our pattern include an uppercase character, 'smartcase' canceling out the 'ignorecase'.  
 >If our pattern include all lowercase, the search will be case insensitive.  
   
-#[Tip71](tip71.md) [Tip73](tip73.md)
+# [Tip71](tip71.md) [Tip73](tip73.md)

--- a/tip73.md
+++ b/tip73.md
@@ -1,7 +1,7 @@
-#Tip73: Use the \v Pattern Switch for Regex Searches
+# Tip73: Use the \v Pattern Switch for Regex Searches
 
 ![tip73_1](images/tip73_1.png)  
 ![tip73_2](images/tip73_2.png)  
 ![tip73_3](images/tip73_3.png)
 
-#[Tip72](tip72.md) [Tip74](tip74.md)
+# [Tip72](tip72.md) [Tip74](tip74.md)

--- a/tip73.md
+++ b/tip73.md
@@ -1,7 +1,7 @@
 # Tip73: Use the \v Pattern Switch for Regex Searches
 
-![tip73_1](images/tip73_1.png)  
-![tip73_2](images/tip73_2.png)  
+![tip73_1](images/tip73_1.png)
+![tip73_2](images/tip73_2.png)
 ![tip73_3](images/tip73_3.png)
 
 # [Tip72](tip72.md) [Tip74](tip74.md)

--- a/tip8.md
+++ b/tip8.md
@@ -1,4 +1,4 @@
-#Tip8: Chunk Your Undos  
+# Tip8: Chunk Your Undos  
   
 The `u` key triggers the undo command, which reverts the most recent change.  
 i{insert some text}<Esc> constitutes a change.  
@@ -6,8 +6,8 @@ From the moment we enter Insert mode until we return to Normal mode, everything 
  
 If I’m in Insert mode with my cursor at the end of a line, the quickest way to open a new line is to press `<CR>`. And yet I sometimes prefer to press `<Esc>o` just because I anticipate that I might want that extra granularity from the undo command.  
   
-#Moving Around in Insert Mode Resets the Change  
+# Moving Around in Insert Mode Resets the Change  
   
 When I said that the undo command would revert all characters entered (or deleted)	during a trip into Insert mode and back, I was glossing over a small detail. If we use the <Up> , <Down> , <Left> , or <Right> cursor keys while in Insert mode, a new undo	chunk is created. It’s just as though we had switched back to Normal mode to move around with the h , j , k , or l commands, except that we don’t have to leave Insert mode. This also has implications on the operation of the dot command.  
   
-#[Tip7](tip7.md)  [Tip9](tip9.md)
+# [Tip7](tip7.md)  [Tip9](tip9.md)

--- a/tip8.md
+++ b/tip8.md
@@ -1,13 +1,13 @@
-# Tip8: Chunk Your Undos  
-  
-The `u` key triggers the undo command, which reverts the most recent change.  
-i{insert some text}<Esc> constitutes a change.  
-From the moment we enter Insert mode until we return to Normal mode, everything we type (or delete) counts as a single change. So we can make the undo command operate on words, sentences, or paragraphs just by moderating our use of the `<Esc>` key.  
- 
-If I’m in Insert mode with my cursor at the end of a line, the quickest way to open a new line is to press `<CR>`. And yet I sometimes prefer to press `<Esc>o` just because I anticipate that I might want that extra granularity from the undo command.  
-  
-# Moving Around in Insert Mode Resets the Change  
-  
-When I said that the undo command would revert all characters entered (or deleted)	during a trip into Insert mode and back, I was glossing over a small detail. If we use the <Up> , <Down> , <Left> , or <Right> cursor keys while in Insert mode, a new undo	chunk is created. It’s just as though we had switched back to Normal mode to move around with the h , j , k , or l commands, except that we don’t have to leave Insert mode. This also has implications on the operation of the dot command.  
-  
+# Tip8: Chunk Your Undos
+
+The `u` key triggers the undo command, which reverts the most recent change.
+i{insert some text}<Esc> constitutes a change.
+From the moment we enter Insert mode until we return to Normal mode, everything we type (or delete) counts as a single change. So we can make the undo command operate on words, sentences, or paragraphs just by moderating our use of the `<Esc>` key.
+
+If I’m in Insert mode with my cursor at the end of a line, the quickest way to open a new line is to press `<CR>`. And yet I sometimes prefer to press `<Esc>o` just because I anticipate that I might want that extra granularity from the undo command.
+
+# Moving Around in Insert Mode Resets the Change
+
+When I said that the undo command would revert all characters entered (or deleted)	during a trip into Insert mode and back, I was glossing over a small detail. If we use the <Up> , <Down> , <Left> , or <Right> cursor keys while in Insert mode, a new undo	chunk is created. It’s just as though we had switched back to Normal mode to move around with the h , j , k , or l commands, except that we don’t have to leave Insert mode. This also has implications on the operation of the dot command.
+
 # [Tip7](tip7.md)  [Tip9](tip9.md)

--- a/tip9.md
+++ b/tip9.md
@@ -1,31 +1,31 @@
-#Tip9: Compose Repeatable Change  
+# Tip9: Compose Repeatable Change  
   
 `Goal`: delete the word `nigh`  
   
-##Delete Backward  
+## Delete Backward  
 ![tip9_1](images/tip9_1.png)  
   
-##db  
+## db  
 >delete from the cursor's starting position to the beginning of the word, but it leaves the final **h** intact.  
 **comment**: dot repeats the single character deletion(`.` == `x`)  
   
 
-##Delete Forward  
+## Delete Forward  
 ![tip9_2](images/tip9_2.png)  
   
-##b  
+## b  
 >put the cursor into position of the starting of the word.  
   
 
-##dw  
+## dw  
 >delete from the cursor position to the begining of the next word.  
 **comment**: dot isn't useful cause cursor is already at end of the line(no next word).  at least: `.` == `dw`
   
-##Delete an Entire Word  
+## Delete an Entire Word  
 ![tip9_3](images/tip9_3.png)  
   
-##daw  
+## daw  
 >delete the current word and also delete a whitespace character.  
 **comment**: dot repeats the instruction to delete a word. `.` == `daw`  
   
-#[Tip8](tip8.md)  [Tip10](tip10.md)
+# [Tip8](tip8.md)  [Tip10](tip10.md)

--- a/tip9.md
+++ b/tip9.md
@@ -1,31 +1,31 @@
-# Tip9: Compose Repeatable Change  
-  
-`Goal`: delete the word `nigh`  
-  
-## Delete Backward  
-![tip9_1](images/tip9_1.png)  
-  
-## db  
->delete from the cursor's starting position to the beginning of the word, but it leaves the final **h** intact.  
-**comment**: dot repeats the single character deletion(`.` == `x`)  
-  
+# Tip9: Compose Repeatable Change
 
-## Delete Forward  
-![tip9_2](images/tip9_2.png)  
-  
-## b  
->put the cursor into position of the starting of the word.  
-  
+`Goal`: delete the word `nigh`
 
-## dw  
->delete from the cursor position to the begining of the next word.  
+## Delete Backward
+![tip9_1](images/tip9_1.png)
+
+## db
+>delete from the cursor's starting position to the beginning of the word, but it leaves the final **h** intact.
+**comment**: dot repeats the single character deletion(`.` == `x`)
+
+
+## Delete Forward
+![tip9_2](images/tip9_2.png)
+
+## b
+>put the cursor into position of the starting of the word.
+
+
+## dw
+>delete from the cursor position to the begining of the next word.
 **comment**: dot isn't useful cause cursor is already at end of the line(no next word).  at least: `.` == `dw`
-  
-## Delete an Entire Word  
-![tip9_3](images/tip9_3.png)  
-  
-## daw  
->delete the current word and also delete a whitespace character.  
-**comment**: dot repeats the instruction to delete a word. `.` == `daw`  
-  
+
+## Delete an Entire Word
+![tip9_3](images/tip9_3.png)
+
+## daw
+>delete the current word and also delete a whitespace character.
+**comment**: dot repeats the instruction to delete a word. `.` == `daw`
+
 # [Tip8](tip8.md)  [Tip10](tip10.md)


### PR DESCRIPTION
Thanks for this wonderful project!

Markdown headers need an extra space to be rendered correctly. This little PR simply fixes it. It should now look better within Github – anywhere where it is rendered, really!